### PR TITLE
Add expanded combos for RPR

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -49,6 +49,11 @@
                 SpinningScythe = 25,
                 InfernalSlice = 30,
                 NightmareScythe = 45,
+                BloodStalk = 50,
+                GrimSwathe = 55,
+                Gibbet = 70,
+                Gallows = 70,
+                Guillotine = 70,
                 Enshroud = 80,
                 PlentifulHarvest = 88,
                 Communio = 90;
@@ -164,6 +169,111 @@
             {
                 if (level >= RPR.Levels.Communio && HasEffect(RPR.Buffs.Enshrouded))
                     return RPR.Communio;
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class GibbetSliceCombo : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.ReaperGibbetSliceCombo;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == RPR.Gibbet)
+            {
+                if (comboTime > 0)
+                {
+                    if (lastComboMove == RPR.Slice && level >= RPR.Levels.WaxingSlice)
+                        return RPR.WaxingSlice;
+
+                    if (lastComboMove == RPR.WaxingSlice && level >= RPR.Levels.InfernalSlice)
+                        return RPR.InfernalSlice;
+                }
+
+                // Check if we're in Soul Reaver or Enshrouded
+                if (HasEffect(RPR.Buffs.SoulReaver) || HasEffect(RPR.Buffs.Enshrouded))
+                {
+                    // If we have Enhanced Gibbet/Void Reaping and Soul Reaver/Shroud, this should always be next cast
+                    if ((HasEffect(RPR.Buffs.EnhancedGibbet) || HasEffect(RPR.Buffs.EnhancedVoidReaping)) && level >= RPR.Levels.Gibbet)
+                        return RPR.Gibbet;
+                    // Same for Gallows
+                    if ((HasEffect(RPR.Buffs.EnhancedGallows) || HasEffect(RPR.Buffs.EnhancedCrossReaping)) && level >= RPR.Levels.Gallows)
+                        return RPR.Gallows;
+
+                    // If we don't have enhanced, but are in Soul Reaver/Shroud, return Gibbet
+                    if (level >= RPR.Levels.Gibbet)
+                        return RPR.Gibbet;
+                }
+
+                // Return slice if nothing else to do
+                return RPR.Slice;
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class GallowsSliceCombo : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.ReaperGallowsSliceCombo;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == RPR.Gallows)
+            {
+                if (comboTime > 0)
+                {
+                    if (lastComboMove == RPR.Slice && level >= RPR.Levels.WaxingSlice)
+                        return RPR.WaxingSlice;
+
+                    if (lastComboMove == RPR.WaxingSlice && level >= RPR.Levels.InfernalSlice)
+                        return RPR.InfernalSlice;
+                }
+
+                // Check if we're in Soul Reaver or Shroud
+                if (HasEffect(RPR.Buffs.SoulReaver) || HasEffect(RPR.Buffs.Enshrouded))
+                {
+                    // If we have Enhanced Gibbet/Void Reaping and Soul Reaver/Shroud, this should always be next cast
+                    if ((HasEffect(RPR.Buffs.EnhancedGibbet) || HasEffect(RPR.Buffs.EnhancedVoidReaping)) && level >= RPR.Levels.Gibbet)
+                        return RPR.Gibbet;
+                    // Same for Gallows
+                    if ((HasEffect(RPR.Buffs.EnhancedGallows) || HasEffect(RPR.Buffs.EnhancedCrossReaping)) && level >= RPR.Levels.Gallows)
+                        return RPR.Gallows;
+
+                    // If we don't have enhanced, but are in Soul Reaver/Shroud, return Gibbet
+                    if (level >= RPR.Levels.Gibbet)
+                        return RPR.Gallows;
+                }
+
+                // Return slice if nothing else to do
+                return RPR.Slice;
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class GuillotineScytheCombo : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.ReaperGuillotineScytheCombo;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == RPR.Guillotine)
+            {
+                if (comboTime > 0)
+                {
+                    if (lastComboMove == RPR.SpinningScythe && level >= RPR.Levels.NightmareScythe)
+                        return RPR.NightmareScythe;
+                }
+
+                // If we're in Soul Reaver/Shroud, return Guillotine
+                if ((HasEffect(RPR.Buffs.SoulReaver) || HasEffect(RPR.Buffs.Enshrouded)) && level >= RPR.Levels.Guillotine)
+                    return RPR.Guillotine;
+
+                return RPR.SpinningScythe;
             }
 
             return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -314,13 +314,27 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Slice Combo", "Replace Infernal Slice with its combo chain.", RPR.JobID)]
         ReaperSliceCombo = 3901,
 
-        [CustomComboInfo("Scythe Combo", "Replace Nightmare Scythe with its combo chain.", RPR.JobID)]
+        [OrderedEnum]
+        [CustomComboInfo("Gibbet Slice Combo", "Replace Gibbet with the slice combo chain. Also changes to Gibbet/Gallows under Soul Reaver and Void/Cross Reaping under Enshroud", RPR.JobID, RPR.Gibbet)]
+        ReaperGibbetSliceCombo = 3906,
+
+        [OrderedEnum]
+        [CustomComboInfo("Gallows Slice Combo", "Replace Gallows with the slice combo chain. Also changes to Gibbet/Gallows under Soul Reaver and Void/Cross Reaping under Enshroud", RPR.JobID, RPR.Gallows)]
+        ReaperGallowsSliceCombo = 3907,
+
+        [OrderedEnum]
+        [CustomComboInfo("Scythe Combo", "Replace Nightmare Scythe with its combo chain.", RPR.JobID, RPR.NightmareScythe)]
         ReaperScytheCombo = 3902,
+
+        [OrderedEnum]
+        [CustomComboInfo("Guillotine Scythe Combo", "Replace Guillotine with the Scythe combo chain. Also changes to Guillotine under Soul Reaver and Grim Reaping under Enshroud", RPR.JobID, RPR.SpinningScythe)]
+        ReaperGuillotineScytheCombo = 3908,
 
         // [CustomComboInfo("Soul Reaver Feature", "Replace Infernal Slice and Blood Stalk with .", RPR.JobID)]
         // ReaperSoulReaverFeature = 3903,
 
-        [CustomComboInfo("Arcane Harvest Feature", "Replace Arcane Circle with Plentiful Harvest when you have stacks of Immortal Sacrifice.", RPR.JobID)]
+        [OrderedEnum]
+        [CustomComboInfo("Arcane Harvest Feature", "Replace Arcane Circle with Plentiful Harvest when you have stacks of Immortal Sacrifice.", RPR.JobID, RPR.ArcaneCircle)]
         ReaperHarvestFeature = 3904,
 
         [CustomComboInfo("Enshroud Communio Feature", "Replace Enshroud with Communio when Enshrouded.", RPR.JobID)]


### PR DESCRIPTION
Think I did this right, though I wasn't sure how to get the ability/buff IDs. Those queue times amirite

I noticed that pretty much you'd always want to have Gibbet/Gallows take priority over the basic combo when under Soul Reaver (I believe this is the same behavior in pvp), and you'd never want to not cycle them, I replicated the effect for the AoE combo

I'm not sure there's ever a case where it would be necessary to have any of these on separate buttons, Jump/Mirage Dive style

This plugin overall has been a game changer in terms of how much more fun the game is