### PR TITLE
SMN: Fix Painflare

### DIFF
--- a/XIVComboExpanded/Combos/SMN.cs
+++ b/XIVComboExpanded/Combos/SMN.cs
@@ -36,7 +36,6 @@ namespace XIVComboExpandedPlugin.Combos
         {
             public const byte
                 RadiantAegis = 2,
-                Painflare = 52,
                 Ruin3 = 54,
                 Ruin4 = 62,
                 SearingLight = 66,
@@ -94,9 +93,6 @@ namespace XIVComboExpandedPlugin.Combos
                     if (level >= SMN.Levels.Ruin4 && HasEffect(SMN.Buffs.FurtherRuin))
                         return SMN.Ruin4;
                 }
-
-                // Painflare
-                return OriginalHook(SMN.EnergySyphon);
             }
 
             return actionID;


### PR DESCRIPTION
Energy siphon is now a higher level than Painflare so there's no need to check painflare's level. The order of operations can now go:

No aetherflow stacks? Energy siphon (can't use painflare anyway)
Ruin 4 feature on + correct level/buff? Ruin 4
Else actionID, which will return Painflare anyway if applicable (doesn't matter after the checks)

Tested and working ingame.