### PR TITLE
[GNB] Add Burst Strike feature

### DIFF
--- a/XIVComboExpanded/Combos/GNB.cs
+++ b/XIVComboExpanded/Combos/GNB.cs
@@ -48,6 +48,7 @@ namespace XIVComboExpandedPlugin.Combos
                 NoMercy = 2,
                 BrutalShell = 4,
                 SolidBarrel = 26,
+                BurstStrike = 30,
                 DemonSlaughter = 40,
                 SonicBreak = 54,
                 BowShock = 62,
@@ -73,7 +74,18 @@ namespace XIVComboExpandedPlugin.Combos
                 if (comboTime > 0)
                 {
                     if (lastComboMove == GNB.BrutalShell && level >= GNB.Levels.SolidBarrel)
+                    {
+                        if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeFeature))
+                        {
+                            var gauge = GetJobGauge<GNBGauge>();
+                            var maxAmmo = level >= GNB.Levels.CartridgeCharge2 ? 3 : 2;
+
+                            if (level >= GNB.Levels.BurstStrike && gauge.Ammo == maxAmmo)
+                                return GNB.BurstStrike;
+                        }
+
                         return GNB.SolidBarrel;
+                    }
 
                     if (lastComboMove == GNB.KeenEdge && level >= GNB.Levels.BrutalShell)
                         return GNB.BrutalShell;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -260,6 +260,9 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Double Down Feature", "Replace Burst Strike and Fated Circle with Double Down when available.", GNB.JobID)]
         GunbreakerDoubleDownFeature = 3709,
 
+        [CustomComboInfo("Burst Strike Feature", "In addition to the Solid Barrel combo, add Burst Strike when charges are full.", GNB.JobID)]
+        GunbreakerBurstStrikeFeature = 3710,
+
         #endregion
         // ====================================================================================
         #region MACHINIST


### PR DESCRIPTION
Hope I added everything correctly. This is basically the Fated Circle feature but for the single target combo (spending a cartridge before adding another via the combo). I did a quick test in-game and it's working fine. 