### PR TITLE
[RPR] Soul Slice Reaping and Enshroud combos

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -14,6 +14,9 @@ namespace XIVComboExpandedPlugin.Combos
             // AoE
             SpinningScythe = 24376,
             NightmareScythe = 24377,
+            // Generators
+            SoulSlice = 24380,
+            SoulScythe = 24381,
             // Soul Reaver
             BloodStalk = 24389,
             Gibbet = 24382,
@@ -232,6 +235,46 @@ namespace XIVComboExpandedPlugin.Combos
                         return OriginalHook(RPR.Gallows);
 
                     if (IsEnabled(CustomComboPreset.ReaperShadowGibbetFeature))
+                        // Void Reaping
+                        return OriginalHook(RPR.Gibbet);
+                }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class ReaperSoulSlice : ReaperCustomCombo
+    {
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == RPR.SoulSlice)
+            {
+                var gauge = GetJobGauge<RPRGauge>();
+
+                if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
+                {
+                    if (IsEnabled(CustomComboPreset.ReaperSoulCommunioFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
+                        return RPR.Communio;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperSoulLemuresFeature))
+                    {
+                        if (level >= RPR.Levels.EnhancedShroud && gauge.VoidShroud >= 2)
+                        return RPR.LemuresSlice;
+                }
+                }
+
+                if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                    (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
+                {
+                    if (IsEnabled(CustomComboPreset.ReaperSoulGallowsFeature))
+                        // Cross Reaping
+                        return OriginalHook(RPR.Gallows);
+
+                    if (IsEnabled(CustomComboPreset.ReaperSoulGibbetFeature))
                         // Void Reaping
                         return OriginalHook(RPR.Gibbet);
                 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -437,6 +437,20 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Shadow Communio Feature", "Replace Shadow of Death with Communio when one stack of Shroud is left.", RPR.JobID)]
         ReaperShadowCommunioFeature = 3924,
 
+        [ConflictingCombos(ReaperSoulGibbetFeature)]
+        [CustomComboInfo("Soul Gallows Feature", "Replace Soul Slice with Gallows while Reaving or Enshrouded.", RPR.JobID)]
+        ReaperSoulGallowsFeature = 3925,
+
+        [ConflictingCombos(ReaperSoulGallowsFeature)]
+        [CustomComboInfo("Soul Gibbet Feature", "Replace Soul Slice with Gibbet while Reaving or Enshrouded.", RPR.JobID)]
+        ReaperSoulGibbetFeature = 3926,
+
+        [CustomComboInfo("Soul Lemure's Feature", "Replace Soul Slice with Lemure's Slice when two or more stacks of Void Shroud are active.", RPR.JobID)]
+        ReaperSoulLemuresFeature = 3927,
+
+        [CustomComboInfo("Soul Communio Feature", "Replace Soul Slice with Communio when one stack of Shroud is left.", RPR.JobID)]
+        ReaperSoulCommunioFeature = 3928,
+
         [CustomComboInfo("Scythe Combo", "Replace Nightmare Scythe with its combo chain.", RPR.JobID)]
         ReaperScytheCombo = 3902,
 


### PR DESCRIPTION
Added combo for [RPR] Soul Slice to convert to Gibbet/Gallows, Communio, and Lemure's Slice.

Fixes #62.

*NOTE:* I am not a C# developer by trade, and I don't have my local environment well-configured for it.  There may be mistakes in this, please look over it carefully and/or simply use it as a starting point for your own similar changes.