### PR TITLE
Nest child features

### DIFF
--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -220,6 +220,10 @@ namespace XIVComboExpandedPlugin
                 if (!Service.Configuration.EnabledActions.Contains(parentVal))
                 {
                     Service.Configuration.EnabledActions.Add(parentVal);
+                    foreach (var conflict in Service.Configuration.GetConflicts(parentVal))
+                    {
+                        Service.Configuration.EnabledActions.Remove(conflict);
+                    }
                 }
 
                 parent = this.childToParentPresets[parentVal];

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -102,7 +102,7 @@ namespace XIVComboExpandedPlugin
             var enabled = Service.Configuration.IsEnabled(preset);
             var secret = Service.Configuration.IsSecret(preset);
             var conflicts = Service.Configuration.GetConflicts(preset);
-            var children = Service.Configuration.GetChildren(preset);
+
             if (ImGui.Checkbox(info.FancyName, ref enabled))
             {
                 if (enabled)
@@ -187,16 +187,20 @@ namespace XIVComboExpandedPlugin
 
             i++;
 
-            if (enabled && children.Any())
+            if (enabled)
             {
-                ImGui.Indent();
-                ImGui.Indent();
-                foreach (var (childPreset, childInfo) in children)
+                var children = Service.Configuration.GetChildren(preset);
+                if (children.Any())
                 {
-                    this.DrawPreset(childPreset, childInfo, ref i);
+                    ImGui.Indent();
+                    ImGui.Indent();
+                    foreach (var (childPreset, childInfo) in children)
+                    {
+                        this.DrawPreset(childPreset, childInfo, ref i);
+                    }
+                    ImGui.Unindent();
+                    ImGui.Unindent();
                 }
-                ImGui.Unindent();
-                ImGui.Unindent();
             }
         }
     }

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -34,6 +34,7 @@ namespace XIVComboExpandedPlugin
                 .Select(preset => (Preset: preset, Info: preset.GetAttribute<CustomComboInfoAttribute>()))
                 .Where(tpl => tpl.Info != null)
                 .OrderBy(tpl => tpl.Info.JobName)
+                .ThenBy(tpl => Service.Configuration.GetChildren(tpl.Preset).Any()) // Move combos with children to top
                 .ThenBy(tpl => tpl.Info.Order)
                 .GroupBy(tpl => tpl.Info.JobName)
                 .ToDictionary(
@@ -75,99 +76,14 @@ namespace XIVComboExpandedPlugin
                 {
                     foreach (var (preset, info) in this.groupedPresets[jobName])
                     {
-                        var enabled = Service.Configuration.IsEnabled(preset);
                         var secret = Service.Configuration.IsSecret(preset);
-                        var conflicts = Service.Configuration.GetConflicts(preset);
                         var parent = Service.Configuration.GetParent(preset);
-
-                        if (secret && !showSecrets)
+                        if (parent != null || (secret && !showSecrets))
                             continue;
 
                         ImGui.PushItemWidth(200);
 
-                        if (ImGui.Checkbox(info.FancyName, ref enabled))
-                        {
-                            if (enabled)
-                            {
-                                Service.Configuration.EnabledActions.Add(preset);
-                                foreach (var conflict in conflicts)
-                                {
-                                    Service.Configuration.EnabledActions.Remove(conflict);
-                                }
-                            }
-                            else
-                            {
-                                Service.Configuration.EnabledActions.Remove(preset);
-                            }
-
-                            Service.Configuration.Save();
-                        }
-
-                        if (secret)
-                        {
-                            ImGui.SameLine();
-                            ImGui.Text("  ");
-                            ImGui.SameLine();
-                            ImGui.PushFont(UiBuilder.IconFont);
-                            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                            ImGui.Text(FontAwesomeIcon.Star.ToIconString());
-                            ImGui.PopStyleColor();
-                            ImGui.PopFont();
-
-                            if (ImGui.IsItemHovered())
-                            {
-                                ImGui.BeginTooltip();
-                                ImGui.TextUnformatted("Secret");
-                                ImGui.EndTooltip();
-                            }
-                        }
-
-                        ImGui.PopItemWidth();
-
-                        var description = $"#{i}: {info.Description}";
-                        if (parent != null)
-                        {
-                            var parentInfo = parent.GetAttribute<CustomComboInfoAttribute>();
-                            description += $"\nRequires {parentInfo.FancyName}";
-                        }
-
-                        ImGui.PushStyleColor(ImGuiCol.Text, this.shadedColor);
-                        ImGui.TextWrapped(description);
-                        ImGui.PopStyleColor();
-                        ImGui.Spacing();
-
-                        if (conflicts.Length > 0)
-                        {
-                            var conflictText = conflicts.Select(preset =>
-                            {
-                                var info = preset.GetAttribute<CustomComboInfoAttribute>();
-                                return $"\n - {info.FancyName}";
-                            }).Aggregate((t1, t2) => $"{t1}{t2}");
-
-                            ImGui.TextColored(this.shadedColor, $"Conflicts with: {conflictText}");
-                            ImGui.Spacing();
-                        }
-
-                        if (preset == CustomComboPreset.DancerDanceComboCompatibility && enabled)
-                        {
-                            var actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
-
-                            var inputChanged = false;
-                            inputChanged |= ImGui.InputInt("Emboite (Red) ActionID", ref actions[0], 0);
-                            inputChanged |= ImGui.InputInt("Entrechat (Blue) ActionID", ref actions[1], 0);
-                            inputChanged |= ImGui.InputInt("Jete (Green) ActionID", ref actions[2], 0);
-                            inputChanged |= ImGui.InputInt("Pirouette (Yellow) ActionID", ref actions[3], 0);
-
-                            if (inputChanged)
-                            {
-                                Service.Configuration.DancerDanceCompatActionIDs = actions.Cast<uint>().ToArray();
-                                Service.Configuration.Save();
-                            }
-
-                            ImGui.Spacing();
-                        }
-
-                        i++;
+                        this.DrawPreset(preset, info, ref i);
                     }
                 }
                 else
@@ -179,6 +95,109 @@ namespace XIVComboExpandedPlugin
             ImGui.PopStyleVar();
 
             ImGui.EndChild();
+        }
+
+        private void DrawPreset(CustomComboPreset preset, CustomComboInfoAttribute info, ref int i)
+        {
+            var enabled = Service.Configuration.IsEnabled(preset);
+            var secret = Service.Configuration.IsSecret(preset);
+            var conflicts = Service.Configuration.GetConflicts(preset);
+            var children = Service.Configuration.GetChildren(preset);
+            if (ImGui.Checkbox(info.FancyName, ref enabled))
+            {
+                if (enabled)
+                {
+                    Service.Configuration.EnabledActions.Add(preset);
+                    foreach (var conflict in conflicts)
+                    {
+                        Service.Configuration.EnabledActions.Remove(conflict);
+                    }
+                }
+                else
+                {
+                    Service.Configuration.EnabledActions.Remove(preset);
+                }
+
+                Service.Configuration.Save();
+            }
+
+            if (secret)
+            {
+                ImGui.SameLine();
+                ImGui.Text("  ");
+                ImGui.SameLine();
+                ImGui.PushFont(UiBuilder.IconFont);
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
+                ImGui.Text(FontAwesomeIcon.Star.ToIconString());
+                ImGui.PopStyleColor();
+                ImGui.PopFont();
+
+                if (ImGui.IsItemHovered())
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.TextUnformatted("Secret");
+                    ImGui.EndTooltip();
+                }
+            }
+
+            ImGui.PopItemWidth();
+
+            var description = $"#{i}: {info.Description}";
+            /*if (parent != null)
+            {
+                var parentInfo = parent.GetAttribute<CustomComboInfoAttribute>();
+                description += $"\nRequires {parentInfo.FancyName}";
+            }*/
+
+            ImGui.PushStyleColor(ImGuiCol.Text, this.shadedColor);
+            ImGui.TextWrapped(description);
+            ImGui.PopStyleColor();
+            ImGui.Spacing();
+
+            if (conflicts.Length > 0)
+            {
+                var conflictText = conflicts.Select(preset =>
+                {
+                    var info = preset.GetAttribute<CustomComboInfoAttribute>();
+                    return $"\n - {info.FancyName}";
+                }).Aggregate((t1, t2) => $"{t1}{t2}");
+
+                ImGui.TextColored(this.shadedColor, $"Conflicts with: {conflictText}");
+                ImGui.Spacing();
+            }
+
+            if (preset == CustomComboPreset.DancerDanceComboCompatibility && enabled)
+            {
+                var actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
+
+                var inputChanged = false;
+                inputChanged |= ImGui.InputInt("Emboite (Red) ActionID", ref actions[0], 0);
+                inputChanged |= ImGui.InputInt("Entrechat (Blue) ActionID", ref actions[1], 0);
+                inputChanged |= ImGui.InputInt("Jete (Green) ActionID", ref actions[2], 0);
+                inputChanged |= ImGui.InputInt("Pirouette (Yellow) ActionID", ref actions[3], 0);
+
+                if (inputChanged)
+                {
+                    Service.Configuration.DancerDanceCompatActionIDs = actions.Cast<uint>().ToArray();
+                    Service.Configuration.Save();
+                }
+
+                ImGui.Spacing();
+            }
+
+            i++;
+
+            if (enabled && children.Any())
+            {
+                ImGui.Indent();
+                ImGui.Indent();
+                foreach (var (childPreset, childInfo) in children)
+                {
+                    this.DrawPreset(childPreset, childInfo, ref i);
+                }
+                ImGui.Unindent();
+                ImGui.Unindent();
+            }
         }
     }
 }

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -73,6 +73,13 @@ namespace XIVComboExpandedPlugin
                 ImGui.EndTooltip();
             }
 
+            var hideChildren = Service.Configuration.HideDisabledFeaturesChildren;
+            if (ImGui.Checkbox("Hide children of disabled features", ref hideChildren))
+            {
+                Service.Configuration.HideDisabledFeaturesChildren = hideChildren;
+                Service.Configuration.Save();
+            }
+
             ImGui.BeginChild("scrolling", new Vector2(0, -1), true);
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 5));
@@ -194,16 +201,20 @@ namespace XIVComboExpandedPlugin
 
             i++;
 
-            if (this.parentToChildrenPresets[preset].Any())
+            var hideChildren = Service.Configuration.HideDisabledFeaturesChildren;
+            if (!hideChildren || enabled)
             {
-                ImGui.Indent();
-                ImGui.Indent();
-                foreach (var childPreset in this.parentToChildrenPresets[preset])
+                if (this.parentToChildrenPresets[preset].Any())
                 {
-                    this.DrawPreset(childPreset.Preset, childPreset.Info, ref i);
+                    ImGui.Indent();
+                    ImGui.Indent();
+                    foreach (var childPreset in this.parentToChildrenPresets[preset])
+                    {
+                        this.DrawPreset(childPreset.Preset, childPreset.Info, ref i);
+                    }
+                    ImGui.Unindent();
+                    ImGui.Unindent();
                 }
-                ImGui.Unindent();
-                ImGui.Unindent();
             }
         }
 

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -210,6 +210,9 @@ namespace XIVComboExpandedPlugin
                     ImGui.Indent();
                     foreach (var childPreset in this.parentToChildrenPresets[preset])
                     {
+                        var isSecret = Service.Configuration.IsSecret(childPreset.Preset);
+                        if (isSecret && !Service.Configuration.EnableSecretCombos)
+                            continue;
                         this.DrawPreset(childPreset.Preset, childPreset.Info, ref i);
                     }
                     ImGui.Unindent();

--- a/XIVComboExpanded/PluginConfiguration.cs
+++ b/XIVComboExpanded/PluginConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Dalamud.Configuration;
 using Dalamud.Utility;
@@ -86,5 +87,18 @@ namespace XIVComboExpandedPlugin
         /// <returns>The parent preset.</returns>
         public CustomComboPreset? GetParent(CustomComboPreset preset)
             => preset.GetAttribute<ParentComboAttribute>()?.ParentPreset;
+
+        /// <summary>
+        /// Gets the children combo presets, or an empty list.
+        /// </summary>
+        /// <param name="preset">Preset to check.</param>
+        /// <returns>List of (preset, info attribute) tuples.</returns>
+        internal (CustomComboPreset Preset, CustomComboInfoAttribute Info)[] GetChildren(
+            CustomComboPreset preset)
+            => Enum.GetValues(typeof(CustomComboPreset))
+                .Cast<CustomComboPreset>()
+                .Where(pre => this.GetParent(pre) != null && this.GetParent(pre) == preset)
+                .Select(pre => (pre, pre.GetAttribute<CustomComboInfoAttribute>()))
+                .ToArray();
     }
 }

--- a/XIVComboExpanded/PluginConfiguration.cs
+++ b/XIVComboExpanded/PluginConfiguration.cs
@@ -89,10 +89,10 @@ namespace XIVComboExpandedPlugin
             => preset.GetAttribute<ParentComboAttribute>()?.ParentPreset;
 
         /// <summary>
-        /// Gets the children combo presets, or an empty list.
+        /// Gets the children combo presets, or an empty array.
         /// </summary>
         /// <param name="preset">Preset to check.</param>
-        /// <returns>List of (preset, info attribute) tuples.</returns>
+        /// <returns>Array of (preset, info attribute) tuples.</returns>
         internal (CustomComboPreset Preset, CustomComboInfoAttribute Info)[] GetChildren(
             CustomComboPreset preset)
             => Enum.GetValues(typeof(CustomComboPreset))

--- a/XIVComboExpanded/PluginConfiguration.cs
+++ b/XIVComboExpanded/PluginConfiguration.cs
@@ -40,6 +40,12 @@ namespace XIVComboExpandedPlugin
         public bool EnableSecretCombos { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to hide the children of a feature if it is disabled.
+        /// </summary>
+        [JsonProperty("HideDisabledFeaturesChildren")]
+        public bool HideDisabledFeaturesChildren { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets an array of 4 ability IDs to interact with the <see cref="CustomComboPreset.DancerDanceComboCompatibility"/> combo.
         /// </summary>
         public uint[] DancerDanceCompatActionIDs { get; set; } = new uint[]


### PR DESCRIPTION
Quick and dirty solution to an idea I had - when a feature is a child of another, nest it under the parent and only show it when the parent is enabled, in a similar fashion to how some of the checkbox elements in Simple Tweaks work. 

[Preview](https://i.imgur.com/cYSwyDa.gifv)

To comment on what I did with the code:

- Add a GetChildren method to the configuration file.
- Pull out the code responsible for drawing the actual features into its own method, so it can be called recursively.

Right now I think GetChildren is a fairly expensive operation to be called on every frame, so ideally the children would be made more readily available should this change make it in - I just wanted to get a proof of concept working to get your thoughts on it.

Edit: added a commit to only get children if the feature is enabled to alleviate this issue somewhat.

