### PR TITLE
[NIN] Ninjitu to Fleeting/Forked Raiju

### DIFF
--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -279,4 +279,26 @@ namespace XIVComboExpandedPlugin.Combos
             return actionID;
         }
     }
+
+    internal class NinjaNinjitsu : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinAny;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID == NIN.Ninjutsu)
+            {
+                if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady) && !HasEffect(NIN.Buffs.Mudra))
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinjitsuForkedRaijuFeature))
+                        return NIN.ForkedRaiju;
+
+                    if (IsEnabled(CustomComboPreset.NinjaNinjitsuFleetingRaijuFeature))
+                        return NIN.FleetingRaiju;
+                }
+            }
+            
+            return actionID;
+        }
+    }
 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -473,6 +473,14 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Aeolian Edge / Raiju Feature", "Replace the Aeolian Edge combo with Fleeting Raiju when available.", NIN.JobID)]
         NinjaAeolianEdgeRaijuFeature = 3013,
 
+        [ConflictingCombos(NinjaNinjitsuFleetingRaijuFeature)]
+        [CustomComboInfo("Ninjitsu to Forked Raiju Feature", "Replace Ninjitsu with Forked Raiju when available and no Mudra are active.", NIN.JobID)]
+        NinjaNinjitsuForkedRaijuFeature = 3017,
+
+        [ConflictingCombos(NinjaNinjitsuForkedRaijuFeature)]
+        [CustomComboInfo("Ninjitsu to Fleeting Raiju Feature", "Replace Ninjitsu with Fleeting Raiju when available and no Mudra are active.", NIN.JobID)]
+        NinjaNinjitsuFleetingRaijuFeature = 3018,
+
         [ConflictingCombos(NinjaHuraijinFleetingRaijuFeature)]
         [CustomComboInfo("Huraijin / Forked Raiju Feature", "Replace Huraijin with Forked Raiju when available.", NIN.JobID)]
         NinjaHuraijinForkedRaijuFeature = 3011,


### PR DESCRIPTION
Added an option similar to Hurajin's functionality, but using the base Ninjitsu skill. This allows you to spam the skill without accidently using a GCD on hurajin once your Raiju stacks are consumed.

Found it covered a use case where the same button that performs a Raiton does the Raiju "combo" follow up, but doesn't require chaining Hurajin -> Ninjitsu and Hurajin -> Raiju.