### PR TITLE
[NIN] Aeolian Edge / Huton Feature

### DIFF
--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace XIVComboExpandedPlugin.Combos
 {
@@ -88,6 +89,20 @@ namespace XIVComboExpandedPlugin.Combos
                 {
                     if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                         return OriginalHook(NIN.Ninjutsu);
+                }
+
+                if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeHutonFeature))
+                {
+                    var gauge = GetJobGauge<NINGauge>();
+
+                    if (gauge.HutonTimer <= 0 && level >= NIN.Levels.Huraijin)
+                        return NIN.Huraijin;
+
+                    if (gauge.HutonTimer <= 40 * 1000)
+                    {
+                        if (comboTime > 0 && lastComboMove == NIN.GustSlash && level >= NIN.Levels.ArmorCrush)
+                            return NIN.ArmorCrush;
+                    }
                 }
 
                 if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeCombo))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -481,6 +481,9 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Huraijin / Fleeting Raiju Option", "Replace Huraijin with Fleeting Raiju when available.", NIN.JobID)]
         NinjaHuraijinFleetingRaijuFeature = 3014,
 
+        [CustomComboInfo("Aeolian Edge / Huton Feature", "Replaces the Aeolian Edge combo with Armor Crush and Huraijin where appropriate.", NIN.JobID)]
+        NinjaAeolianEdgeHutonFeature = 3017,
+
         #endregion
         // ====================================================================================
         #region PALADIN


### PR DESCRIPTION
Adds a feature to replace Aeolian Edge with Armor Crush when Huton is less than equal to 40 seconds, and Huraijin when Huton is inactive.