### PR TITLE
Basic Monk Combos

### DIFF
--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -238,23 +238,20 @@ namespace XIVComboExpandedPlugin.Combos
                         return OriginalHook(MNK.MasterfulBlitz);
                 }
 
-                if (IsEnabled(CustomComboPreset.MonkDragonKickCombo))
+                if (HasEffect(MNK.Buffs.OpoOpoForm) || HasEffect(MNK.Buffs.FormlessFist) || HasEffect(MNK.Buffs.PerfectBalance))
                 {
-                    if (HasEffect(MNK.Buffs.OpoOpoForm) || HasEffect(MNK.Buffs.FormlessFist) || HasEffect(MNK.Buffs.PerfectBalance))
+                    if (IsEnabled(CustomComboPreset.MonkBootshineFeature))
                     {
-                        if (IsEnabled(CustomComboPreset.MonkBootshineFeature))
-                        {
-                            if (!HasEffect(MNK.Buffs.LeadenFist) && level >= MNK.Levels.DragonKick)
-                                return MNK.DragonKick;
-                        }
-
-                        return actionID;
+                        if (!HasEffect(MNK.Buffs.LeadenFist) && level >= MNK.Levels.DragonKick)
+                            return MNK.DragonKick;
                     }
 
-                    if (HasEffect(MNK.Buffs.RaptorForm)) return level < MNK.Levels.TrueStrike ? MNK.Bootshine : MNK.TrueStrike;
-
-                    if (HasEffect(MNK.Buffs.CoerlForm)) return level < MNK.Levels.SnapPunch ? MNK.Bootshine : MNK.SnapPunch;
+                    return actionID;
                 }
+
+                if (HasEffect(MNK.Buffs.RaptorForm)) return level < MNK.Levels.TrueStrike ? MNK.Bootshine : MNK.TrueStrike;
+
+                if (HasEffect(MNK.Buffs.CoerlForm)) return level < MNK.Levels.SnapPunch ? MNK.Bootshine : MNK.SnapPunch;
             }
 
             return actionID;

--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -17,6 +17,7 @@ namespace XIVComboExpandedPlugin.Combos
             DragonKick = 74,
             SnapPunch = 56,
             TwinSnakes = 61,
+            TrueStrike = 54,
             ArmOfTheDestroyer = 62,
             Demolish = 66,
             PerfectBalance = 69,
@@ -53,7 +54,10 @@ namespace XIVComboExpandedPlugin.Combos
         public static class Levels
         {
             public const byte
+                TrueStrike = 4,
+                SnapPunch = 6,
                 Meditation = 15,
+                TwinSnakes = 18,
                 ArmOfTheDestroyer = 26,
                 Rockbreaker = 30,
                 Demolish = 30,
@@ -180,13 +184,76 @@ namespace XIVComboExpandedPlugin.Combos
                         return OriginalHook(MNK.MasterfulBlitz);
                 }
 
-                if (IsEnabled(CustomComboPreset.MonkBootshineFeature))
+                if (IsEnabled(CustomComboPreset.MonkBootshineFeature) && !IsEnabled(CustomComboPreset.MonkDragonKickCombo))
                 {
                     if (HasEffect(MNK.Buffs.LeadenFist))
                         return MNK.Bootshine;
 
                     if (level < MNK.Levels.DragonKick)
                         return MNK.Bootshine;
+                }
+
+                if (IsEnabled(CustomComboPreset.MonkDragonKickCombo))
+                {
+                    if (HasEffect(MNK.Buffs.OpoOpoForm) || HasEffect(MNK.Buffs.FormlessFist) || HasEffect(MNK.Buffs.PerfectBalance))
+                    {
+                        if (IsEnabled(CustomComboPreset.MonkBootshineFeature))
+                        {
+                            if (HasEffect(MNK.Buffs.LeadenFist))
+                                return MNK.Bootshine;
+                        }
+
+                        return actionID;
+                    }
+
+                    if (HasEffect(MNK.Buffs.RaptorForm)) return MNK.TwinSnakes;
+
+                    if (HasEffect(MNK.Buffs.CoerlForm)) return MNK.Demolish;
+                }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class MonkBootshine : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkAny;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == MNK.Bootshine && IsEnabled(CustomComboPreset.MonkBootshineCombo))
+            {
+                var gauge = GetJobGauge<MNKGauge>();
+
+                if (IsEnabled(CustomComboPreset.MonkBootshineFeature) && IsEnabled(CustomComboPreset.MonkDragonKickMeditationFeature))
+                {
+                    if (level >= MNK.Levels.Meditation && gauge.Chakra < 5 && !HasCondition(ConditionFlag.InCombat))
+                        return MNK.Meditation;
+                }
+
+                if (IsEnabled(CustomComboPreset.MonkBootshineFeature) && IsEnabled(CustomComboPreset.MonkDragonKickBalanceFeature))
+                {
+                    if (!gauge.BeastChakra.Contains(BeastChakra.NONE))
+                        return OriginalHook(MNK.MasterfulBlitz);
+                }
+
+                if (IsEnabled(CustomComboPreset.MonkDragonKickCombo))
+                {
+                    if (HasEffect(MNK.Buffs.OpoOpoForm) || HasEffect(MNK.Buffs.FormlessFist) || HasEffect(MNK.Buffs.PerfectBalance))
+                    {
+                        if (IsEnabled(CustomComboPreset.MonkBootshineFeature))
+                        {
+                            if (!HasEffect(MNK.Buffs.LeadenFist) && level >= MNK.Levels.DragonKick)
+                                return MNK.DragonKick;
+                        }
+
+                        return actionID;
+                    }
+
+                    if (HasEffect(MNK.Buffs.RaptorForm)) return level < MNK.Levels.TrueStrike ? MNK.Bootshine : MNK.TrueStrike;
+
+                    if (HasEffect(MNK.Buffs.CoerlForm)) return level < MNK.Levels.SnapPunch ? MNK.Bootshine : MNK.SnapPunch;
                 }
             }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -403,6 +403,12 @@ namespace XIVComboExpandedPlugin
         // ====================================================================================
         #region MONK
 
+        [CustomComboInfo("Monk Bootshine Combo", "Replace Bootshine with Monk's Bootshine/True Strike/Snap Punch combo.", MNK.JobID)]
+        MonkBootshineCombo = 2013,
+
+        [CustomComboInfo("Monk Dragon Kick Combo", "Replace Dragon Kick with Monk's Dragon Kick/Twin Snakes/Demolish combo.\nYou will still need Demolish/Twin Snakes on your bar for Perfect Balance and Form Shift.", MNK.JobID)]
+        MonkDragonKickCombo = 2014,
+
         [CustomComboInfo("Monk AoE Combo", "Replace Masterful Blitz with the AoE combo chain. This was changed from Rockbreaker due to an action queueing bug.", MNK.JobID)]
         MonkAoECombo = 2001,
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -406,7 +406,7 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Monk Bootshine Combo", "Replace Bootshine with Monk's Bootshine/True Strike/Snap Punch combo.", MNK.JobID)]
         MonkBootshineCombo = 2013,
 
-        [CustomComboInfo("Monk Dragon Kick Combo", "Replace Dragon Kick with Monk's Dragon Kick/Twin Snakes/Demolish combo.\nYou will still need Demolish/Twin Snakes on your bar for Perfect Balance and Form Shift.", MNK.JobID)]
+        [CustomComboInfo("Monk Dragon Kick Combo", "Replace Dragon Kick with Monk's Dragon Kick/Twin Snakes/Demolish combo.\nYou will still need Twin Snakes and Demolish on your bar for Perfect Balance and Form Shift.", MNK.JobID)]
         MonkDragonKickCombo = 2014,
 
         [CustomComboInfo("Monk AoE Combo", "Replace Masterful Blitz with the AoE combo chain. This was changed from Rockbreaker due to an action queueing bug.", MNK.JobID)]


### PR DESCRIPTION
These are simple Monk combos that replace Bootshine with Bootshine/True Strike/Snap Punch, and Dragon Kick with Dragon Kick/Twin Snakes/Demolish.

Tested with all possible level syncs, as well as all Monk features.

While this does still require you to put Twin Snakes/Demolish on your bar for Perfect Balance and Form Shift, overall this saves two buttons (True Strike is never used in PB/Form Shift, and Snap Punch is only used in Perfect Balance very situationally for a marginal DPS gain in a specific rotation, and is also never used in Form Shift). It also just makes Monk a lot more cozy to play overall, in what is a pretty standard, 'legit' way. I figured, while I don't want to put my unholy monstrosity on this fork due to how complex it is to use (since I wanted it to not be cheaty, but I also wanted it to save as many buttons as possible), this should be a pretty good alternative that feels a lot more clean and simple in comparison.