### PR TITLE
[FEATURE] Expanded Monk form features

### DIFF
--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -14,13 +14,14 @@ namespace XIVComboExpandedPlugin.Combos
 
         public const uint
             Bootshine = 53,
-            DragonKick = 74,
+            TrueStrike = 54,
             SnapPunch = 56,
             TwinSnakes = 61,
             ArmOfTheDestroyer = 62,
             Demolish = 66,
             PerfectBalance = 69,
             Rockbreaker = 70,
+            DragonKick = 74,
             Meditation = 3546,
             RiddleOfFire = 7395,
             Brotherhood = 7396,
@@ -187,6 +188,50 @@ namespace XIVComboExpandedPlugin.Combos
 
                     if (level < MNK.Levels.DragonKick)
                         return MNK.Bootshine;
+                }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class MonkTwinSnakesKick : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkAny;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == MNK.TwinSnakes)
+            {
+                if (IsEnabled(CustomComboPreset.MonkTwinSnakesFeature))
+                {
+                    var status = FindEffect(MNK.Buffs.TwinSnakes);
+
+                    if (status is not null && status?.RemainingTime > 6.0) {
+                        return MNK.TrueStrike;
+                    }
+                }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class MonkDemolishKick : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkAny;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == MNK.Demolish)
+            {
+                if (IsEnabled(CustomComboPreset.MonkDemolishFeature))
+                {
+                    var status = FindTargetEffect(MNK.Debuffs.Demolish);
+
+                    if (status is not null && status?.RemainingTime > 6.0) {
+                        return MNK.SnapPunch;
+                    }
                 }
             }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -406,8 +406,14 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Monk AoE Combo", "Replace Masterful Blitz with the AoE combo chain. This was changed from Rockbreaker due to an action queueing bug.", MNK.JobID)]
         MonkAoECombo = 2001,
 
-        [CustomComboInfo("Dragon Bootshine Feature", "Replace Dragon Kick with Bootshine if Leaden Fist is up.", MNK.JobID)]
+        [CustomComboInfo("Dragon Kick / Bootshine Feature", "Replace Dragon Kick with Bootshine if Leaden Fist is up.", MNK.JobID)]
         MonkBootshineFeature = 2011,
+
+        [CustomComboInfo("Twin Snakes / True Strike Feature", "Replace Twin Snakes with True Strike if Twin Snakes has more than 6s remaining.", MNK.JobID)]
+        MonkTwinSnakesFeature = 2013,
+
+        [CustomComboInfo("Demolish / Snap Punch Feature", "Replace Demolish with Snap Punch if Demolish has more than 6s remaining on your current target.", MNK.JobID)]
+        MonkDemolishFeature = 2014,
 
         [CustomComboInfo("Dragon Balance Feature", "Replace Dragon Kick with Masterful Blitz if you have 3 Beast Chakra.", MNK.JobID)]
         MonkDragonKickBalanceFeature = 2005,


### PR DESCRIPTION
- Added a feature combining Twin Snakes and True Strike.
- Added a feature combining Demolish and Snap Punch
- Reworded 'Dragon Bootshine Feature' to 'Dragon Kick / Bootshine Feature'.  Functionality unchanged.

Partially fixes #101 