### PR TITLE
Monk AoE combo update

### DIFF
--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -91,8 +91,8 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= MNK.Levels.PerfectBalance && HasEffect(MNK.Buffs.PerfectBalance))
                 {
-                    // Solar or Both
-                    if (!gauge.Nadi.HasFlag(Nadi.SOLAR) || gauge.Nadi.HasFlag(Nadi.LUNAR))
+                    // Solar
+                    if (!gauge.Nadi.HasFlag(Nadi.SOLAR))
                     {
                         if (level >= MNK.Levels.FourPointFury && !gauge.BeastChakra.Contains(BeastChakra2.RAPTOR))
                             return MNK.FourPointFury;
@@ -109,13 +109,10 @@ namespace XIVComboExpandedPlugin.Combos
                             : MNK.Rockbreaker;
                     }
 
-                    // Lunar
-                    if (!gauge.Nadi.HasFlag(Nadi.LUNAR))
-                    {
-                        return level >= MNK.Levels.ShadowOfTheDestroyer
-                            ? MNK.ShadowOfTheDestroyer
-                            : MNK.Rockbreaker;
-                    }
+                    // Lunar.  Also used if we have both Nadi, as Tornado Kick/Phantom Rush isn't picky.
+                    return level >= MNK.Levels.ShadowOfTheDestroyer
+                        ? MNK.ShadowOfTheDestroyer
+                        : MNK.Rockbreaker;
                 }
 
                 // FPF with FormShift


### PR DESCRIPTION
- Updated Monk AoE combo to use the Lunar sequence (3 of the same) for Tornado Kick/Phantom Rush, because it doesn't require 3 unique Beast Chakra.
- Removed the redundant Lunar Nadi conditional expression, since the prior Solar conditional is terminating.