### PR TITLE
[Feature] Harpe/Harvest Moon options

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -567,7 +567,7 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonFeature))
                 {
-                    if (level >= RPR.Levels.HarvestMoon && HasEffect(RPR.Buffs.Soulsow) && !HasEffect(RPR.Buffs.EnhancedHarpe))
+                    if (level >= RPR.Levels.HarvestMoon && HasEffect(RPR.Buffs.Soulsow) && (!IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonEnhancedFeature) || !HasEffect(RPR.Buffs.EnhancedHarpe)) && (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonCombatFeature) || InCombat()))
                         return RPR.HarvestMoon;
                 }
             }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -663,11 +663,19 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Delayed Regress Option", "Replace the action used with Regress only after 1.5 seconds have elapsed on Threshold.", RPR.JobID)]
         ReaperRegressOption = 3933,
 
-        [CustomComboInfo("Harpe Soulsow Feature", "Replace Harpe with Soulsow when not active and out of combat or you have no target.", RPR.JobID)]
+        [CustomComboInfo("Harpe/Soulsow Feature", "Replace Harpe with Soulsow when not active and out of combat or you have no target.", RPR.JobID)]
         ReaperHarpeHarvestSoulsowFeature = 3936,
 
-        [CustomComboInfo("Harpe Harvest Moon Feature", "Replace Harpe with Harvest Moon when Soulsow is active and Enhanced Harpe is not.", RPR.JobID)]
+        [CustomComboInfo("Harpe/Harvest Moon Feature", "Replace Harpe with Harvest Moon when Soulsow is active and you are in combat.", RPR.JobID)]
         ReaperHarpeHarvestMoonFeature = 3937,
+
+        [ParentCombo(ReaperHarpeHarvestMoonFeature)]
+        [CustomComboInfo("Harpe/Harvest Moon Combat Option", "Harvest Moon also replaces Harpe when you are not in combat.", RPR.JobID)]
+        ReaperHarpeHarvestMoonCombatFeature = 3938,
+
+        [ParentCombo(ReaperHarpeHarvestMoonFeature)]
+        [CustomComboInfo("Harpe/Harvest Moon Enhanced Harpe Option", "Harvest Moon does not replace Harpe when Enhanced Harpe active.", RPR.JobID)]
+        ReaperHarpeHarvestMoonEnhancedFeature = 3939,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
- The Harpe/Harvest Moon feature by default no longer replaces Harpe if not in combat, and now ignores Enhanced Harpe by default.
- Added option for Harvest Moon to also replace Harpe when not in combat.
- Added option for Harvest Moon to defer to Harpe when Enhanced Harpe is active.

The standard Reaper opener, in the presence of a pull timer, is to pre-cast Harpe at 2s.  However, the existing Harvest Moon feature does not permit this, as it will use Harvest Moon even when out of combat.  To fix this, the default state of the feature is to now to only replace Harpe when in combat, and a new subordinate option was added for Harvest Moon to also replace Harpe when not in combat.

In addition, when you must disconnect from the boss, the current guidance is to use Harvest Moon over Harpe even with Enhanced Harpe active, as Harvest Moon is twice the potency (and still instacast), and otherwise only sorta fits in a normal rotation anyway (since it replaces a combo GCD, and thus throws off the Soul Gauge economy a bit).  To align with this, the default state of the feature is now for Harvest Moon to replace Harpe regardless of Enhanced Harpe, and a new subordinate option was added for Harvest Moon to not replace Harpe if Enhanced Harpe is active.

In both of these cases, they alter the existing behavior of the feature and place that existing behavior in a new option.  However, since this feature is very new (only pushed yesterday), I don't believe users will have grown accustomed to it (if they've even noticed it was added), and thus the disruption of this change should be minimal.  The default state of the feature, without either option enabled, is now the "proper" usage of Harvest Moon according to current theorycrafting guidance.