### PR TITLE
[BUGFIX] Use Communio on last Shroud orb even if Void orbs remain

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -111,16 +111,16 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperSliceCommunioFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperSliceLemuresFeature))
                     {
                         if (level >= RPR.Levels.EnhancedShroud && gauge.VoidShroud >= 2)
                             return RPR.LemuresSlice;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperSliceCommunioFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
                 }
 
@@ -187,16 +187,16 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperScytheCommunioFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperScytheLemuresFeature))
                     {
                         if (level >= RPR.Levels.LemuresScythe && gauge.VoidShroud >= 2)
                             return RPR.LemuresScythe;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperScytheCommunioFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
                 }
 
@@ -254,16 +254,16 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperShadowCommunioFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperShadowLemuresFeature))
                     {
                         if (level >= RPR.Levels.EnhancedShroud && gauge.VoidShroud >= 2)
                             return RPR.LemuresSlice;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperShadowCommunioFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
                 }
 
@@ -296,16 +296,16 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperSoulCommunioFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperSoulLemuresFeature))
                     {
                         if (level >= RPR.Levels.EnhancedShroud && gauge.VoidShroud >= 2)
                             return RPR.LemuresSlice;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperSoulCommunioFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
                 }
 
@@ -421,16 +421,16 @@ namespace XIVComboExpandedPlugin.Combos
                 if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
                     (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperCommunioSoulReaverFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperLemuresSoulReaverFeature))
                     {
                         if (level >= RPR.Levels.EnhancedShroud && gauge.VoidShroud >= 2)
                             return RPR.LemuresSlice;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperCommunioSoulReaverFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
 
                     if (IsEnabled(CustomComboPreset.ReaperEnhancedEnshroudedFeature))
@@ -461,16 +461,16 @@ namespace XIVComboExpandedPlugin.Combos
 
                 if (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.ReaperCommunioSoulReaverFeature))
-                    {
-                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1 && gauge.VoidShroud == 0)
-                            return RPR.Communio;
-                    }
-
                     if (IsEnabled(CustomComboPreset.ReaperLemuresSoulReaverFeature))
                     {
                         if (level >= RPR.Levels.LemuresScythe && gauge.VoidShroud >= 2)
                             return RPR.LemuresScythe;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperCommunioSoulReaverFeature))
+                    {
+                        if (level >= RPR.Levels.Communio && gauge.LemureShroud == 1)
+                            return RPR.Communio;
                     }
                 }
             }


### PR DESCRIPTION
- Fixed bug where Communio would be skipped if the player was behind on using Lemure's Slice/Scythe.

**Context:** Currently, if the player has 1 Shroud Orb remaining, but >0 Void Orbs remaining (ie. they forgot to use Lemure's Slice), and do _not_ have the relevant 'X Lemure's Feature' active to automatically integrate Lemure's attacks, if they hit the button that would otherwise turn into Communio (whether that's the Slice combo, the Scythe combo, Soul Slice, Shadow of Death, or Gibbet/Gallows/Guillotine directly), it will instead simply cast Void Reaping or Cross Reaping, whichever is empowered (or Grim Reaping, if it's the AoE version), using the last Shroud Orb and ending Enshroud _without_ casting Communio.

Since failing to cast Communio is even more of a loss than simply missing the Lemure's (especially since it ends Enshroud and thus _also_ prevents using that last Lemure's), I've adjust the code sections to handle this.  It now checks for Lemure's first, if the relevant Lemure's Feature is enabled, and Void Orbs >= 2.  If that is not the case, it unconditionally casts Communio of Shroud Orbs is 1, regardless of whether Void Orbs is at 0.  Since the Lemure's Feature check has been moved first, if it is enabled, Communio will still only be cast once Void Orbs < 2 (which means == 0, since you can only have 0, 2, or 4 if you have 1 Shroud Orb), retaining existing behavior with that feature enabled.  Without it enabled, Communio is used (skipping the remaining Lemure's) rather than Void/Cross/Grim Reaping, skipping _both_ the remaining Lemure's and Communio.