### PR TITLE
[SGE] Toxikon to Phlegma Feature

### DIFF
--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -227,3 +227,26 @@ internal class SagePhlegma : CustomCombo
         return actionID;
     }
 }
+
+internal class SageToxikon : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SgeAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == SGE.Toxikon)
+        {
+            if (IsEnabled(CustomComboPreset.SageToxiconPhlegma))
+            {
+                var phlegma =
+                    level >= SGE.Levels.Phlegma3 ? SGE.Phlegma3 :
+                    level >= SGE.Levels.Phlegma2 ? SGE.Phlegma2 :
+                    level >= SGE.Levels.Phlegma ? SGE.Phlegma : 0;
+                if (phlegma != 0 && GetCooldown(phlegma).CooldownRemaining < 45)
+                    return OriginalHook(SGE.Phlegma);
+            }
+        }
+        return actionID;
+    }
+}
+

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -201,7 +201,7 @@ internal class SagePhlegma : CustomCombo
                     return OriginalHook(SGE.Dyskrasia);
             }
 
-            if (IsEnabled(CustomComboPreset.SagePhlegmaToxicon))
+            if (IsEnabled(CustomComboPreset.SagePhlegmaToxicon) && !IsEnabled(CustomComboPreset.SageToxiconPhlegma))
             {
                 var phlegma =
                     level >= SGE.Levels.Phlegma3 ? SGE.Phlegma3 :
@@ -249,4 +249,3 @@ internal class SageToxikon : CustomCombo
         return actionID;
     }
 }
-

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -795,7 +795,8 @@ public enum CustomComboPreset
     [CustomComboInfo("Phlegma into Dyskrasia", "Replace Phlegma with Dyskrasia when no charges remain or have no target.", SGE.JobID)]
     SagePhlegmaDyskrasia = 4008,
 
-    [CustomComboInfo("Toxikon into Phlegma", "Replace Toxikon with Phlegma when you have charges of Phlemga available.", SGE.JobID)]
+    [ParentCombo(SagePhlegmaToxicon)]
+    [CustomComboInfo("Reverse Swapped Ability", "Replace Toxikon with Phlegma when you have charges of Phlemga available.", SGE.JobID)]
     SageToxiconPhlegma = 4009,
 
     #endregion

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -795,6 +795,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Phlegma into Dyskrasia", "Replace Phlegma with Dyskrasia when no charges remain or have no target.", SGE.JobID)]
     SagePhlegmaDyskrasia = 4008,
 
+    [CustomComboInfo("Toxikon into Phlegma", "Replace Toxikon with Phlegma when you have charges of Phlemga available.", SGE.JobID)]
+    SageToxiconPhlegma = 4009,
+
     #endregion
     // ====================================================================================
     #region SAMURAI


### PR DESCRIPTION
Last PR had it's bogos binted and was pulling from master, fixed now.

Added reverse option for 'Phlegma into Toxikon' Feature so you can see the cooldown of Phlegma after it is used.

Resolves #145