### PR TITLE
Improved Warrior Overcap Protection and 'Storm's Eye Combo' Feature bugfix

### DIFF
--- a/XIVComboExpanded/Combos/WAR.cs
+++ b/XIVComboExpanded/Combos/WAR.cs
@@ -55,6 +55,7 @@ internal static class WAR
             ThrillOfBattle = 30,
             InnerBeast = 35,
             MythrilTempest = 40,
+            SteelCyclone = 45,
             StormsEye = 50,
             Infuriate = 50,
             FellCleave = 54,
@@ -67,6 +68,144 @@ internal static class WAR
             InnerChaos = 80,
             Bloodwhetting = 82,
             PrimalRend = 90;
+    }
+}
+
+internal class WarriorStormsPath : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == WAR.StormsPath)
+        {
+            var gauge = GetJobGauge<WARGauge>();
+
+            if (comboTime > 0)
+            {
+                if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 80)
+                            // Fell Cleave
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+
+                    return WAR.StormsPath;
+                }
+
+                if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim && IsEnabled(CustomComboPreset.WarriorStormsPathCombo))
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 90)
+                            // Fell Cleave
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+                }
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class WarriorStormsEye : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == WAR.StormsEye)
+        {
+            var gauge = GetJobGauge<WARGauge>();
+
+            if (comboTime > 0)
+            {
+                if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsEye)
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 90)
+                            // Fell Cleave
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+
+                    return WAR.StormsEye;
+                }
+
+                if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim && IsEnabled(CustomComboPreset.WarriorStormsEyeCombo))
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 90)
+                            // Fell Cleave
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+                }
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class WarriorMaim : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == WAR.Maim)
+        {
+            var gauge = GetJobGauge<WARGauge>();
+
+            if (comboTime > 0)
+            {
+                if (lastComboMove == WAR.HeavySwing)
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 90)
+                            // Fell Cleave
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+                }
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class WarriorMythrilTempest : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == WAR.MythrilTempest && (level >= WAR.Levels.MythrilTempestTrait))
+        {
+            var gauge = GetJobGauge<WARGauge>();
+
+            if (comboTime > 0)
+            {
+                if (lastComboMove == WAR.Overpower)
+                {
+                    if (IsEnabled(CustomComboPreset.WarriorOvercapProtection))
+                    {
+                        if (gauge.BeastGauge > 80)
+                            // Decimate
+                            return OriginalHook(WAR.SteelCyclone);
+                    }
+
+                    return WAR.MythrilTempest;
+                }
+            }
+        }
+
+        return actionID;
     }
 }
 
@@ -90,24 +229,24 @@ internal class WarriorStormsPathCombo : CustomCombo
             {
                 if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
                 {
-                    if (IsEnabled(CustomComboPreset.WarriorStormsPathOvercapFeature))
+                    /*if (IsEnabled(CustomComboPreset.WarriorStormsPathOvercapFeature))
                     {
                         if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 80)
                             // Fell Cleave
                             return OriginalHook(WAR.InnerBeast);
-                    }
+                    }*/
 
                     return WAR.StormsPath;
                 }
 
                 if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
                 {
-                    if (IsEnabled(CustomComboPreset.WarriorStormsPathOvercapFeature))
+                    /*if (IsEnabled(CustomComboPreset.WarriorStormsPathOvercapFeature))
                     {
                         if (level >= WAR.Levels.InnerBeast && gauge.BeastGauge > 90)
                             // Fell Cleave
                             return OriginalHook(WAR.InnerBeast);
-                    }
+                    }*/
 
                     return WAR.Maim;
                 }
@@ -132,13 +271,13 @@ internal class WarriorStormsEyeCombo : CustomCombo
 
             if (comboTime > 0)
             {
+                if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsEye)
+                    return WAR.StormsEye;
+
                 if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
                 {
                     return WAR.StormsPath;
                 }
-
-                if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsEye)
-                    return WAR.StormsEye;
 
                 if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
                     return WAR.Maim;
@@ -177,11 +316,11 @@ internal class WarriorMythrilTempestCombo : CustomCombo
             {
                 if (lastComboMove == WAR.Overpower && level >= WAR.Levels.MythrilTempest)
                 {
-                    if (IsEnabled(CustomComboPreset.WarriorMythrilTempestOvercapFeature))
+                    /*if (IsEnabled(CustomComboPreset.WarriorMythrilTempestOvercapFeature))
                     {
                         if (level >= WAR.Levels.MythrilTempestTrait && gauge.BeastGauge > 80)
                             return WAR.Decimate;
-                    }
+                    }*/
 
                     return WAR.MythrilTempest;
                 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -947,9 +947,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Storms Path Combo", "Replace Storms Path with its combo chain.", WAR.JobID)]
     WarriorStormsPathCombo = 2101,
 
-    [ParentCombo(WarriorStormsPathCombo)]
+    /*[ParentCombo(WarriorStormsPathCombo)]
     [CustomComboInfo("Storms Path Overcap Feature", "Replace Storms Path with Fell Cleave when the next combo action would cause the Beast Gauge to overcap.", WAR.JobID)]
-    WarriorStormsPathOvercapFeature = 2104,
+    WarriorStormsPathOvercapFeature = 2104,*/
 
     [ParentCombo(WarriorStormsPathCombo)]
     [CustomComboInfo("Storms Path Inner Release Feature", "Replace Storms Path with Fell Cleave when Inner Release is active.", WAR.JobID)]
@@ -964,9 +964,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Mythril Tempest Target Option", "Replace Mythril Tempest only when you have a target.", WAR.JobID)]
     WarriorMythrilTempestTargetOption = 2113,
 
-    [ParentCombo(WarriorMythrilTempestCombo)]
+    /*[ParentCombo(WarriorMythrilTempestCombo)]
     [CustomComboInfo("Mythril Tempest Overcap Feature", "Replace Mythril Tempest with Decimate the next combo action would cause the Beast Gauge to overcap.", WAR.JobID)]
-    WarriorMythrilTempestOvercapFeature = 2105,
+    WarriorMythrilTempestOvercapFeature = 2105,*/
 
     [ParentCombo(WarriorMythrilTempestCombo)]
     [CustomComboInfo("Mythril Tempest Inner Release Feature", "Replace Mythril Tempest with Decimate when Inner Release is active.", WAR.JobID)]
@@ -986,6 +986,9 @@ public enum CustomComboPreset
 
     [CustomComboInfo("Primal Release Feature", "Replace Inner Release with Primal Rend when available", WAR.JobID)]
     WarriorPrimalReleaseFeature = 2108,
+
+    [CustomComboInfo("Warrior Overcap Protection", "Replace Gauge increasing moves with Gauge spending moves when about to overcap", WAR.JobID)]
+    WarriorOvercapProtection = 2114,
 
     #endregion
     // ====================================================================================


### PR DESCRIPTION
### Improved Warrior Overcap Protection:

Now functions regardless of whether you have the Combo Features active or not.

Todo: Add nested option for each Overcap setting

### 'Storm's Eye Combo' Feature Bugfix

This Combo Feature always returned Storm's Path instead of Storm's Eye due to incorrect order of operations. Now fixed.