### PR TITLE
[BRD] Add Wanderer's Minuet Semi-Fix

### DIFF
--- a/XIVComboExpanded/Combos/BRD.cs
+++ b/XIVComboExpanded/Combos/BRD.cs
@@ -21,6 +21,7 @@ internal static class BRD
         BattleVoice = 118,
         EmpyrealArrow = 3558,
         WanderersMinuet = 3559,
+        LegGraze = 7554,
         IronJaws = 3560,
         Sidewinder = 3562,
         PitchPerfect = 7404,
@@ -73,6 +74,25 @@ internal static class BRD
             Ladonsbite = 82,
             BlastShot = 86,
             RadiantFinale = 90;
+    }
+}
+
+internal class BardWanderersMinuet : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardWanderersPitchPerfectFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == BRD.LegGraze)
+        {
+            var gauge = GetJobGauge<BRDGauge>();
+
+            if (level >= BRD.Levels.PitchPerfect && gauge.Song == Song.WANDERER)
+                return BRD.PitchPerfect;
+            return BRD.WanderersMinuet;
+        }
+
+        return actionID;
     }
 }
 

--- a/XIVComboExpanded/Combos/BRD.cs
+++ b/XIVComboExpanded/Combos/BRD.cs
@@ -21,7 +21,7 @@ internal static class BRD
         BattleVoice = 118,
         EmpyrealArrow = 3558,
         WanderersMinuet = 3559,
-        LegGraze = 7554,
+        Peloton = 7557,
         IronJaws = 3560,
         Sidewinder = 3562,
         PitchPerfect = 7404,
@@ -83,7 +83,7 @@ internal class BardWanderersMinuet : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == BRD.LegGraze)
+        if (actionID == BRD.Peloton && CurrentTarget is not null)
         {
             var gauge = GetJobGauge<BRDGauge>();
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -177,6 +177,9 @@ public enum CustomComboPreset
     // ====================================================================================
     #region BARD
 
+    [CustomComboInfo("Wanderer's Minuet Semi-Fix", "Turns Leg Graze into Wanderer's Minuet to Pitch Perfect, letting you use it regardless of whatever other bards are doing.", BRD.JobID)]
+    BardWanderersPitchPerfectFeature = 2301,
+
     [CustomComboInfo("Heavy Shot into Straight Shot", "Replace Heavy Shot with Straight Shot/Refulgent Arrow when available.", BRD.JobID)]
     BardStraightShotUpgradeFeature = 2302,
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -177,7 +177,7 @@ public enum CustomComboPreset
     // ====================================================================================
     #region BARD
 
-    [CustomComboInfo("Wanderer's Minuet Semi-Fix", "Turns Leg Graze into Wanderer's Minuet to Pitch Perfect, letting you use it regardless of whatever other bards are doing.", BRD.JobID)]
+    [CustomComboInfo("Wanderer's Minuet Semi-Fix", "Turns Peloton into Wanderer's Minuet to Pitch Perfect while you have a target, letting you use it regardless of whatever other bards are doing.", BRD.JobID)]
     BardWanderersPitchPerfectFeature = 2301,
 
     [CustomComboInfo("Heavy Shot into Straight Shot", "Replace Heavy Shot with Straight Shot/Refulgent Arrow when available.", BRD.JobID)]


### PR DESCRIPTION
I added this to my plugin, and since it's such a direly needed fix for Bard right now, I decided to make a pull request to add it to make things easier. It simply replaces Peloton (while you have a target) with Wanderer's Minuet to Pitch Perfect, but one that doesn't mess up if other bards use Wanderer's Minuet. I originally tried to put the functionality on wanderer's minuet itself, but it seems that whatever they did doesn't let it work, so I chose peloton while targeting something instead because it has no use during combat. I haven't actually tested this specific version with another player yet, but I did test my own fix on my own end and it worked fine there. This uses the gauge instead to determine if you can use Pitch Perfect or not, so, assuming they didn't mess it up *too* bad, it should work regardless of what other bards are doing.