### PR TITLE
NIN aeolian edge mudra/raiju ready tweak

### DIFF
--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -80,18 +80,18 @@ internal class NinjaAeolianEdge : CustomCombo
         {
             var gauge = GetJobGauge<NINGauge>();
 
-            if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeRaijuFeature))
-            {
-                if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
-                    return NIN.FleetingRaiju;
-            }
-
             if (IsEnabled(CustomComboPreset.NinjaAeolianNinjutsuFeature))
             {
                 if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                     return OriginalHook(NIN.Ninjutsu);
             }
-
+            
+            if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeRaijuFeature))
+            {
+                if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
+                    return NIN.FleetingRaiju;
+            }
+            
             if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeHutonFeature))
             {
                 if (level >= NIN.Levels.Huraijin && gauge.HutonTimer == 0)


### PR DESCRIPTION
For the aeolian edge combo replacement options, if both mudra and raiju ready are up prioritize mudra ability. This is because you can store multiple raiju ready stacks (up to 3), but using fleeting raiju when you're in the middle of a mudra breaks the mudra.