### PR TITLE
[FEATURE] Ninja Ninki Overcap Feature

### DIFF
--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -30,7 +30,9 @@ internal static class NIN
         Huraijin = 25876,
         PhantomKamaitachi = 25774,
         ForkedRaiju = 25777,
-        FleetingRaiju = 25778;
+        FleetingRaiju = 25778,
+        Bhavacakra = 7402,
+        HellfrogMedium = 7401;
 
     public static class Buffs
     {
@@ -61,11 +63,15 @@ internal static class NIN
             HakkeMujinsatsu = 52,
             ArmorCrush = 54,
             Huraijin = 60,
+            Shukiho1 = 62,
+            Bhavacakra = 68,
             TenChiJin = 70,
             Meisui = 72,
             EnhancedKassatsu = 76,
+            Shukiho2 = 78,
             Bunshin = 80,
             PhantomKamaitachi = 82,
+            Shukiho3 = 84,
             Raiju = 90;
     }
 }
@@ -85,22 +91,55 @@ internal class NinjaAeolianEdge : CustomCombo
                 if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                     return OriginalHook(NIN.Ninjutsu);
             }
-            
+
             if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeRaijuFeature))
             {
                 if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
                     return NIN.FleetingRaiju;
+                }
             }
             
             if (IsEnabled(CustomComboPreset.NinjaAeolianEdgeHutonFeature))
             {
                 if (level >= NIN.Levels.Huraijin && gauge.HutonTimer == 0)
-                    return NIN.Huraijin;
-
-                if (comboTime > 0)
                 {
-                    if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.ArmorCrush && gauge.HutonTimer <= 30_000)
-                        return NIN.ArmorCrush;
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
+                    return NIN.Huraijin;
+                }
+
+                if (comboTime > 0 && lastComboMove == NIN.GustSlash && 
+                    level >= NIN.Levels.ArmorCrush && gauge.HutonTimer <= 30_000)
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && (gauge.Ninki > 95 || 
+                            level >= NIN.Levels.Shukiho2 && gauge.Ninki > 90 ||
+                            level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
+                    return NIN.ArmorCrush;
                 }
             }
 
@@ -109,13 +148,56 @@ internal class NinjaAeolianEdge : CustomCombo
                 if (comboTime > 0)
                 {
                     if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.AeolianEdge)
+                    {
+                        if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                        {
+                            if (level >= NIN.Levels.Shukiho1 && (gauge.Ninki > 95 || 
+                                level >= NIN.Levels.Shukiho2 && gauge.Ninki > 90 ||
+                                level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
+                            {
+                                if (level > NIN.Levels.Bhavacakra)
+                                    return NIN.Bhavacakra
+                                return NIN.HellfrogMedium
+                            }
+                        }
                         return NIN.AeolianEdge;
+                    }
 
                     if (lastComboMove == NIN.SpinningEdge && level >= NIN.Levels.GustSlash)
+                    {
+                        if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                        {
+                            if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                            {
+                                if (level > NIN.Levels.Bhavacakra)
+                                    return NIN.Bhavacakra
+                                return NIN.HellfrogMedium
+                            }
+                        }
                         return NIN.GustSlash;
+                    }
                 }
 
+                if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                {
+                    if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                    {
+                        if (level > NIN.Levels.Bhavacakra)
+                            return NIN.Bhavacakra
+                        return NIN.HellfrogMedium
+                    }
+                }
                 return NIN.SpinningEdge;
+            }
+
+            if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+            {
+                if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                {
+                    if (level > NIN.Levels.Bhavacakra)
+                        return NIN.Bhavacakra
+                    return NIN.HellfrogMedium
+                }
             }
         }
 
@@ -131,16 +213,27 @@ internal class NinjaArmorCrush : CustomCombo
     {
         if (actionID == NIN.ArmorCrush)
         {
-            if (IsEnabled(CustomComboPreset.NinjaArmorCrushRaijuFeature))
-            {
-                if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
-                    return NIN.ForkedRaiju;
-            }
-
             if (IsEnabled(CustomComboPreset.NinjaArmorCrushNinjutsuFeature))
             {
                 if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                     return OriginalHook(NIN.Ninjutsu);
+            }
+
+            if (IsEnabled(CustomComboPreset.NinjaArmorCrushRaijuFeature))
+            {
+                if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
+                    return NIN.ForkedRaiju;
+                }
             }
 
             if (IsEnabled(CustomComboPreset.NinjaArmorCrushCombo))
@@ -148,13 +241,59 @@ internal class NinjaArmorCrush : CustomCombo
                 if (comboTime > 0)
                 {
                     if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.ArmorCrush)
+                    {
+                        if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                        {
+                            if (level >= NIN.Levels.Shukiho1 && (gauge.Ninki > 95 || 
+                                level >= NIN.Levels.Shukiho2 && gauge.Ninki > 90 ||
+                                level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
+                            {
+                                if (level > NIN.Levels.Bhavacakra)
+                                    return NIN.Bhavacakra
+                                return NIN.HellfrogMedium
+                            }
+                        }
                         return NIN.ArmorCrush;
+                    }
 
                     if (lastComboMove == NIN.SpinningEdge && level >= NIN.Levels.GustSlash)
+                    {
+                        if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                        {
+                            if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                            {
+                                if (level > NIN.Levels.Bhavacakra)
+                                    return NIN.Bhavacakra
+                                return NIN.HellfrogMedium
+                            }
+                        }
                         return NIN.GustSlash;
+                    }
                 }
 
-                return NIN.SpinningEdge;
+                if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                {
+                    if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                    {
+                        if (level > NIN.Levels.Bhavacakra)
+                            return NIN.Bhavacakra
+                        return NIN.HellfrogMedium
+                    }
+                }
+
+               return NIN.SpinningEdge;
+            }
+
+            if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+            {
+                if (level >= NIN.Levels.Shukiho1 && (gauge.Ninki >= 95 || 
+                    level >= NIN.Levels.Shukiho2 && gauge.Ninki >= 90 ||
+                    level >= NIN.Levels.Shukiho3 && gauge.Ninki >= 85))
+                {
+                    if (level > NIN.Levels.Bhavacakra)
+                        return NIN.Bhavacakra
+                    return NIN.HellfrogMedium
+                }
             }
         }
 
@@ -170,19 +309,41 @@ internal class NinjaHuraijin : CustomCombo
     {
         if (actionID == NIN.Huraijin)
         {
-            if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
-            {
-                if (IsEnabled(CustomComboPreset.NinjaHuraijinForkedRaijuFeature))
-                    return NIN.ForkedRaiju;
-
-                if (IsEnabled(CustomComboPreset.NinjaHuraijinFleetingRaijuFeature))
-                    return NIN.FleetingRaiju;
-            }
-
             if (IsEnabled(CustomComboPreset.NinjaHuraijinNinjutsuFeature))
             {
                 if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                     return OriginalHook(NIN.Ninjutsu);
+            }
+
+            if (level >= NIN.Levels.Raiju && HasEffect(NIN.Buffs.RaijuReady))
+            {
+                if (IsEnabled(CustomComboPreset.NinjaHuraijinForkedRaijuFeature))
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
+                    return NIN.ForkedRaiju;
+                }
+
+                if (IsEnabled(CustomComboPreset.NinjaHuraijinFleetingRaijuFeature))
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                    {
+                        if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                        {
+                            if (level > NIN.Levels.Bhavacakra)
+                                return NIN.Bhavacakra
+                            return NIN.HellfrogMedium
+                        }
+                    }
+                    return NIN.FleetingRaiju;
+                }
             }
 
             if (IsEnabled(CustomComboPreset.NinjaHuraijinArmorCrushCombo))
@@ -192,7 +353,30 @@ internal class NinjaHuraijin : CustomCombo
                 if (comboTime > 0 && gauge.HutonTimer > 0)
                 {
                     if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.ArmorCrush)
+                    {
+                        if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+                        {
+                            if (level >= NIN.Levels.Shukiho1 && (gauge.Ninki > 95 || 
+                                level >= NIN.Levels.Shukiho2 && gauge.Ninki > 90 ||
+                                level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
+                            {
+                                if (level > NIN.Levels.Bhavacakra)
+                                    return NIN.Bhavacakra
+                                return NIN.HellfrogMedium
+                            }
+                        }
                         return NIN.ArmorCrush;
+                    }
+                }
+            }
+
+            if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+            {
+                if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                {
+                    if (level > NIN.Levels.Bhavacakra)
+                        return NIN.Bhavacakra
+                    return NIN.HellfrogMedium
                 }
             }
         }
@@ -213,6 +397,14 @@ internal class NinjaHakkeMujinsatsu : CustomCombo
             {
                 if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
                     return OriginalHook(NIN.Ninjutsu);
+            }
+
+            if (IsEnabled(CustomComboPreset.NinjaNinkiOvercapFeature))
+            {
+                if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
+                {
+                    return NIN.HellfrogMedium
+                }
             }
 
             if (IsEnabled(CustomComboPreset.NinjaHakkeMujinsatsuCombo))

--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -101,8 +101,8 @@ internal class NinjaAeolianEdge : CustomCombo
                         if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.FleetingRaiju;
@@ -118,8 +118,8 @@ internal class NinjaAeolianEdge : CustomCombo
                         if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.Huraijin;
@@ -135,8 +135,8 @@ internal class NinjaAeolianEdge : CustomCombo
                             level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.ArmorCrush;
@@ -156,8 +156,8 @@ internal class NinjaAeolianEdge : CustomCombo
                                 level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
                             {
                                 if (level > NIN.Levels.Bhavacakra)
-                                    return NIN.Bhavacakra
-                                return NIN.HellfrogMedium
+                                    return NIN.Bhavacakra;
+                                return NIN.HellfrogMedium;
                             }
                         }
                         return NIN.AeolianEdge;
@@ -170,8 +170,8 @@ internal class NinjaAeolianEdge : CustomCombo
                             if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                             {
                                 if (level > NIN.Levels.Bhavacakra)
-                                    return NIN.Bhavacakra
-                                return NIN.HellfrogMedium
+                                    return NIN.Bhavacakra;
+                                return NIN.HellfrogMedium;
                             }
                         }
                         return NIN.GustSlash;
@@ -183,8 +183,8 @@ internal class NinjaAeolianEdge : CustomCombo
                     if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                     {
                         if (level > NIN.Levels.Bhavacakra)
-                            return NIN.Bhavacakra
-                        return NIN.HellfrogMedium
+                            return NIN.Bhavacakra;
+                        return NIN.HellfrogMedium;
                     }
                 }
                 return NIN.SpinningEdge;
@@ -195,8 +195,8 @@ internal class NinjaAeolianEdge : CustomCombo
                 if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                 {
                     if (level > NIN.Levels.Bhavacakra)
-                        return NIN.Bhavacakra
-                    return NIN.HellfrogMedium
+                        return NIN.Bhavacakra;
+                    return NIN.HellfrogMedium;
                 }
             }
         }
@@ -228,8 +228,8 @@ internal class NinjaArmorCrush : CustomCombo
                         if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.ForkedRaiju;
@@ -249,8 +249,8 @@ internal class NinjaArmorCrush : CustomCombo
                                 level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
                             {
                                 if (level > NIN.Levels.Bhavacakra)
-                                    return NIN.Bhavacakra
-                                return NIN.HellfrogMedium
+                                    return NIN.Bhavacakra;
+                                return NIN.HellfrogMedium;
                             }
                         }
                         return NIN.ArmorCrush;
@@ -263,8 +263,8 @@ internal class NinjaArmorCrush : CustomCombo
                             if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                             {
                                 if (level > NIN.Levels.Bhavacakra)
-                                    return NIN.Bhavacakra
-                                return NIN.HellfrogMedium
+                                    return NIN.Bhavacakra;
+                                return NIN.HellfrogMedium;
                             }
                         }
                         return NIN.GustSlash;
@@ -276,8 +276,8 @@ internal class NinjaArmorCrush : CustomCombo
                     if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                     {
                         if (level > NIN.Levels.Bhavacakra)
-                            return NIN.Bhavacakra
-                        return NIN.HellfrogMedium
+                            return NIN.Bhavacakra;
+                        return NIN.HellfrogMedium;
                     }
                 }
 
@@ -291,8 +291,8 @@ internal class NinjaArmorCrush : CustomCombo
                     level >= NIN.Levels.Shukiho3 && gauge.Ninki >= 85))
                 {
                     if (level > NIN.Levels.Bhavacakra)
-                        return NIN.Bhavacakra
-                    return NIN.HellfrogMedium
+                        return NIN.Bhavacakra;
+                    return NIN.HellfrogMedium;
                 }
             }
         }
@@ -324,8 +324,8 @@ internal class NinjaHuraijin : CustomCombo
                         if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.ForkedRaiju;
@@ -338,8 +338,8 @@ internal class NinjaHuraijin : CustomCombo
                         if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                         {
                             if (level > NIN.Levels.Bhavacakra)
-                                return NIN.Bhavacakra
-                            return NIN.HellfrogMedium
+                                return NIN.Bhavacakra;
+                            return NIN.HellfrogMedium;
                         }
                     }
                     return NIN.FleetingRaiju;
@@ -361,8 +361,8 @@ internal class NinjaHuraijin : CustomCombo
                                 level >= NIN.Levels.Shukiho3 && gauge.Ninki > 85))
                             {
                                 if (level > NIN.Levels.Bhavacakra)
-                                    return NIN.Bhavacakra
-                                return NIN.HellfrogMedium
+                                    return NIN.Bhavacakra;
+                                return NIN.HellfrogMedium;
                             }
                         }
                         return NIN.ArmorCrush;
@@ -375,8 +375,8 @@ internal class NinjaHuraijin : CustomCombo
                 if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                 {
                     if (level > NIN.Levels.Bhavacakra)
-                        return NIN.Bhavacakra
-                    return NIN.HellfrogMedium
+                        return NIN.Bhavacakra;
+                    return NIN.HellfrogMedium;
                 }
             }
         }
@@ -403,7 +403,7 @@ internal class NinjaHakkeMujinsatsu : CustomCombo
             {
                 if (level >= NIN.Levels.Shukiho1 && gauge.Ninki > 95)
                 {
-                    return NIN.HellfrogMedium
+                    return NIN.HellfrogMedium;
                 }
             }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -576,6 +576,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Hide to Mug", "Replace Hide with Mug while in combat.", NIN.JobID)]
     NinjaHideMugFeature = 3007,
 
+    [CustomComboInfo("Ninki Overcap Feature", "Replace Ninki-generating abilities with Bhavacakra or Hellfrog Medium to prevent overcapping Ninki.", NIN.JobID)]
+    NinjaNinkiOvercapFeature = 3020,
+
     #endregion
     // ====================================================================================
     #region PALADIN
@@ -684,7 +687,7 @@ public enum CustomComboPreset
     [CustomComboInfo("Scythe Guillotine Feature", "Replace Nightmare Scythe with Guillotine while Reaving or Enshrouded.", RPR.JobID)]
     ReaperScytheGuillotineFeature = 3907,
 
-    [CustomComboInfo("Scythe Lemure's Feature", "Replace Nightmare Scythe with Lemure's Slice when two or more stacks of Void Shroud are active.", RPR.JobID)]
+    [CustomComboInfo("Scythe Lemure's Feature", "Replace Nightmare Scythe with Lemure's Scythe when two or more stacks of Void Shroud are active.", RPR.JobID)]
     ReaperScytheLemuresFeature = 3921,
 
     [CustomComboInfo("Scythe Communio Feature", "Replace Nightmare Scythe with Communio when one stack is left of Shroud.", RPR.JobID)]


### PR DESCRIPTION
- Added the Ninji Overcap feature
  - This feature replaces all Ninki-generating abilities with Bhavacakra or Hellfrog Medium if using the ability would overcap Ninki.
  - Conditionals are slightly complex, as Armor Crush and Aeolian Edge generate 5, 10, or 15, depending on level, whilst everything else generates 5.
  - Bhavacakra is used for all single-target abilities, unless under level 68 (when Bhavacakra is learned)
  - AoE abilities use Hellfrog Medium instead, as do single target abilities when between 62 and 68.

- Moved the Ninjitsu conditional in the Armor Crush and Huraijin blocks above the Raiju conditional, as Mudras break (rabbit) if you use Raiju before Ninjitsu.

- Fixed typo in Reaper "Scythe Lemure's Feature" (fixes #186).

As usual, I'm not a master at C#, nor have I figured out local testing of mods, so the code may require some tweaks to it.