### PR TITLE
Fix PLD combos broken by 6.3 rework

### DIFF
--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -31,8 +31,7 @@ internal static class PLD
     {
         public const ushort
             Requiescat = 1368,
-            SwordOath = 1902,
-            BladeOfFaithReady = 3019;
+            SwordOath = 1902;
     }
 
     public static class Debuffs
@@ -59,39 +58,6 @@ internal static class PLD
             BladeOfFaith = 90,
             BladeOfTruth = 90,
             BladeOfValor = 90;
-    }
-}
-
-internal class PaladinGoringBlade : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PldAny;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == PLD.GoringBlade)
-        {
-            if (IsEnabled(CustomComboPreset.PaladinGoringBladeAtonementFeature))
-            {
-                if (level >= PLD.Levels.Atonement && HasEffect(PLD.Buffs.SwordOath) && lastComboMove != PLD.FastBlade && lastComboMove != PLD.RiotBlade)
-                    return PLD.Atonement;
-            }
-
-            if (IsEnabled(CustomComboPreset.PaladinGoringBladeCombo))
-            {
-                if (comboTime > 0)
-                {
-                    if (lastComboMove == PLD.RiotBlade && level >= PLD.Levels.GoringBlade)
-                        return PLD.GoringBlade;
-
-                    if (lastComboMove == PLD.FastBlade && level >= PLD.Levels.RiotBlade)
-                        return PLD.RiotBlade;
-                }
-
-                return PLD.FastBlade;
-            }
-        }
-
-        return actionID;
     }
 }
 
@@ -158,21 +124,8 @@ internal class PaladinHolySpiritHolyCircle : CustomCombo
     {
         if (actionID == PLD.HolySpirit || actionID == PLD.HolyCircle)
         {
-            if (lastComboMove == PLD.BladeOfTruth && level >= PLD.Levels.BladeOfValor)
-                return PLD.BladeOfValor;
-
-            if (lastComboMove == PLD.BladeOfFaith && level >= PLD.Levels.BladeOfTruth)
-                return PLD.BladeOfTruth;
-
-            if (level >= PLD.Levels.BladeOfFaith && HasEffect(PLD.Buffs.BladeOfFaithReady))
-                return PLD.BladeOfFaith;
-
-            if (level >= PLD.Levels.Confiteor)
-            {
-                var requiescat = FindEffect(PLD.Buffs.Requiescat);
-                if (requiescat != null && (requiescat.StackCount == 1 || LocalPlayer?.CurrentMp < 2000))
-                    return PLD.Confiteor;
-            }
+            if (level >= PLD.Levels.Confiteor && HasEffect(PLD.Buffs.Requiescat))
+                return OriginalHook(PLD.Confiteor);
         }
 
         return actionID;
@@ -187,21 +140,8 @@ internal class PaladinRequiescat : CustomCombo
     {
         if (actionID == PLD.Requiescat)
         {
-            if (lastComboMove == PLD.BladeOfTruth && level >= PLD.Levels.BladeOfValor)
-                return PLD.BladeOfValor;
-
-            if (lastComboMove == PLD.BladeOfFaith && level >= PLD.Levels.BladeOfTruth)
-                return PLD.BladeOfTruth;
-
-            if (level >= PLD.Levels.BladeOfFaith && HasEffect(PLD.Buffs.BladeOfFaithReady))
-                return PLD.BladeOfFaith;
-
-            if (level >= PLD.Levels.Confiteor)
-            {
-                var requiescat = FindEffect(PLD.Buffs.Requiescat);
-                if (requiescat != null)
-                    return PLD.Confiteor;
-            }
+            if (level >= PLD.Levels.Confiteor && HasEffect(PLD.Buffs.Requiescat))
+                return OriginalHook(PLD.Confiteor);
         }
 
         return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -583,17 +583,9 @@ public enum CustomComboPreset
     // ====================================================================================
     #region PALADIN
 
-    [CustomComboInfo("Goring Blade Combo", "Replace Goring Blade with its combo chain.", PLD.JobID)]
-    PaladinGoringBladeCombo = 1901,
-
-    [ConflictingCombos(PaladinRoyalAuthorityAtonementFeature)]
-    [CustomComboInfo("Goring Blade Atonement Feature", "Replace Goring Blade with Atonement when under the effect of Sword Oath.", PLD.JobID)]
-    PaladinGoringBladeAtonementFeature = 1909,
-
     [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority with its combo chain.", PLD.JobID)]
     PaladinRoyalAuthorityCombo = 1902,
 
-    [ConflictingCombos(PaladinGoringBladeAtonementFeature)]
     [CustomComboInfo("Royal Authority Atonement Feature", "Replace Royal Authority with Atonement when under the effect of Sword Oath.", PLD.JobID)]
     PaladinRoyalAuthorityAtonementFeature = 1903,
 
@@ -604,7 +596,7 @@ public enum CustomComboPreset
     PaladinRequiescatCombo = 1905,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Confiteor Feature", "Replace Holy Spirit/Circle with Confiteor when Requiescat is up and MP is under 2000 or only one stack remains.", PLD.JobID)]
+    [CustomComboInfo("Confiteor Feature", "Replace Holy Spirit/Circle with Confiteor while under the effect of Requiescat.", PLD.JobID)]
     PaladinConfiteorFeature = 1907,
 
     [SecretCustomCombo]


### PR DESCRIPTION
This makes the folowing changes:
1. Removes the Goring Blade Combo and Goring Blade Atonement Feature options.<br> *(Goring blade is no longer part of any combos and these no longer work with paladin's new rotation.)*
2. Fix the Requiescat Confiteor option.
3. Make the Confiteor Feature option unconditionally switch to the Confiteor combo when under the effect of Requiescat.<br> *(With the changes, it never makes sense to use Requiescat for Holy Spirit or Holy Circle.)*

The Requiescat Confiteor and Confiteor Feature options are effectively identical now, they just apply to different base actions. The implementations could be combined fairly easily, but I was uneasy about making that kind of structural change. It might also make sense to remove the `[SecretCustomCombo]` attribute from the Confiteor Feature option (and maybe rename it as well), but I have not done so here.