### PR TITLE
Ninja replace Hide with Ninjutsu

### DIFF
--- a/XIVComboExpanded/Combos/NIN.cs
+++ b/XIVComboExpanded/Combos/NIN.cs
@@ -250,14 +250,19 @@ internal class NinjaKassatsu : CustomCombo
 
 internal class NinjaHide : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaHideMugFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
         if (actionID == NIN.Hide)
         {
-            if (level >= NIN.Levels.Mug && InCombat())
-                return NIN.Mug;
+            if (IsEnabled(CustomComboPreset.NinjaHideMugFeature))
+                if (level >= NIN.Levels.Mug && InCombat())
+                    return NIN.Mug;
+
+            if (IsEnabled(CustomComboPreset.NinjaHideNinjutsuFeature))
+                if (level >= NIN.Levels.Ninjitsu && HasEffect(NIN.Buffs.Mudra))
+                    return OriginalHook(NIN.Ninjutsu);
         }
 
         return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -576,8 +576,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Kassatsu Chi/Jin Feature", "Replace Chi with Jin while Kassatsu is up if you have Enhanced Kassatsu.", NIN.JobID)]
     NinjaKassatsuChiJinFeature = 3006,
 
+    [ConflictingCombos(NinjaHideNinjutsuFeature)]
     [CustomComboInfo("Hide to Mug", "Replace Hide with Mug while in combat.", NIN.JobID)]
     NinjaHideMugFeature = 3007,
+
+    [ConflictingCombos(NinjaHideMugFeature)]
+    [CustomComboInfo("Hide to Ninjutsu", "Replace Hide with Ninjutsu with Ninjutsu if any Mudra are used.", NIN.JobID)]
+    NinjaHideNinjutsuFeature = 3020,
 
     #endregion
     // ====================================================================================


### PR DESCRIPTION
A common opener is to Huton into Hide, so putting them onto the same button is ergonomic. Hide and Ninjutsu are also mutually exclusive actions, with Hide activating bunnies if under Mudras.