### PR TITLE
WAR: Avoid using Storms Eye if IR would overcap Surging Tempest

### DIFF
--- a/XIVComboExpanded/Combos/WAR.cs
+++ b/XIVComboExpanded/Combos/WAR.cs
@@ -1,3 +1,4 @@
+using System;
 using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace XIVComboExpandedPlugin.Combos;
@@ -106,7 +107,9 @@ internal class WarriorStormsPathCombo : CustomCombo
                     if (HasEffect(ADV.Buffs.Medicated) && surgingTempest.RemainingTime > 10)
                         return WAR.StormsPath;
 
-                    if (surgingTempest.RemainingTime < 30)
+                    var innerReleleaseCd = GetCooldown(WAR.InnerRelease).CooldownRemaining;
+                    var surgingTempestFromIR = Math.Max(0, 10 - innerReleleaseCd);
+                    if (surgingTempest.RemainingTime + 30 + surgingTempestFromIR < 60)
                         return WAR.StormsEye;
 #endif
 


### PR DESCRIPTION
Using Storm's Eye while there's between 20-30s of Surging Tempest remaining could lead to overcap if Inner Release is used soon afterwards. This PR modifies Storm's Eye usage criteria such that it would only be selected if Surging Tempest wouldn't be overcapped even if IR is used as soon as it comes off of cooldown.