### PR TITLE
[FEATURE] Paladin Requiescat refinement

### DIFF
--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -605,20 +605,20 @@ public enum CustomComboPreset
     [CustomComboInfo("Prominence Divine Might Feature", "Replace Prominence with Holy Circle when Divine Might is active.", PLD.JobID)]
     PaladinProminenceDivineMightFeature = 1913,
 
-    [CustomComboInfo("Fight or Flight Goring Blade Feature", "Replace Fight or Flight with Goring Blade while Fight or Flight is active.", PLD.JobID)]
-    PaladinFightOrFlightGoringBladeFeature = 1911,
+    [CustomComboInfo("Requiescat Fight or Flight Feature", "Replace Requiescat with Fight or Flight when off cooldown or if it will be ready sooner.", PLD.JobID)]
+    PaladinRequiescatFightOrFlightFeature = 1914,
 
-    [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor while under the effect of Requiescat.", PLD.JobID)]
+    [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor and combo chain while under the effect of Requiescat, and then with Holy Spirit if there are remaining charges.", PLD.JobID)]
     PaladinRequiescatCombo = 1905,
 
-    [CustomComboInfo("Requiescat Fight or Flight Feature", "Replace Requiescat with Fight or Flight when off cooldown.", PLD.JobID)]
-    PaladinRequiescatFightOrFlightFeature = 1914,
+    [CustomComboInfo("Fight or Flight Goring Blade Feature", "Replace Fight or Flight with Goring Blade while Fight or Flight is active.  Also applies to Requiescat if the Requiescat Fight or Flight Feature is enabled.", PLD.JobID)]
+    PaladinFightOrFlightGoringBladeFeature = 1911,
 
     [CustomComboInfo("Confiteor Feature", "Replace Holy Spirit/Circle with Confiteor while under the effect of Requiescat.", PLD.JobID)]
     PaladinConfiteorFeature = 1907,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Scornful Spirits Feature", "Replace Spirits Within and Circle of Scorn with whichever is available soonest.", PLD.JobID)]
+    [CustomComboInfo("Scornful Spirits Feature", "Replace Spirits Within/Expiacion and Circle of Scorn with whichever is available soonest.", PLD.JobID)]
     PaladinScornfulSpiritsFeature = 1908,
 
     [CustomComboInfo("Shields on your Feet Feature", "Replace Shield Bash with Low Blow when available.", PLD.JobID)]


### PR DESCRIPTION
- If the Royal Authority Divine Might Feature is enabled, Holy Spirit will be cast preferentially over Atonment and the rest of the combo chain during the Fight or Flight buff, due to the increased potency.
- Same principle applies if Prominence Divine Might Feature is enabled, Holy Circle is prioritized during FoF.
- FoF is only replaced with Goring Blade if Goring Blade is off cooldown.  This just makes the button revert back to FoF after Goring Blade is used, rather than only once FoF fades.
- If both the Requiescat FoF feature and the FoF Goring Blade feature are enabled, Goring Blade is also placed on the Requiescat button during the buff.
  - Goring Blade is used preferentially over the Confiteor combo, because despite doing less potency than Confiteor, Goring Blade requires melee range and the Confiteor chain does not.  Since Req also requires melee range, using Goring Blade immediately after Req is more reliable.
- During Requiescat, Holy Spirit will replace the Requiescat button if the player has remaining Requiescat charges OR if they have Divine Might, rather than only in the former case.
- If the Requiescat FoF feature is enabled, FoF will replace Requiescat if FoF is off cooldown OR if FoF will be ready before Requiescat (which should always be the case except immediately following usage of FoF and before using Req).
  - This ensures that the button consistently shows what the next ability usable on it is or will be, rather than changing to FoF at the last instant when FoF comes off cooldown a single weave window before Req, as it behaves now.
- Reworded several Paladin combo descriptions to better indicate their behavior and to note interactions with other features, and reordered a few for better grouping.

These changes are predominantly to address what I see as shortcomings or limitations of how the features are currently implemented.  With these changes, one should be able to condense FoF, Requiescat, the entire Confiteor chain, and Goring Blade into a single button.  In addition, the higher potency Divine Might casts will be preferred during FoF, avoiding the need to juggle between buttons to use them during FoF.  One can now simply use the Requiescat button repeatedly to use FoF -> Requiescat -> Goring Blade -> Confiteor chain, then return to using the Royal Authority button as normal without losing the potency of Divine Might being backloaded after Atonement in the RA combo.  Under ideal circumstances (ie. enter FoF with Divine Might active and Royal Authority as the next combo action), this will results in Holy Spirit -> Royal Authority -> Holy Spirit being used as the last 3 GCDs of FoF, all being used automatically via the Royal Authority button, which is the optimal sequence from a potency perspective.

I'm also considering seeing if I can tackle the logic of automating Atonement cancelations (or more likely, simply _ignoring_ and overwriting Atonement as needed) for optimal FoF alignment.  Obviously would be a secret combo, but would this be worth putting in a PR as well?