### PR TITLE
Monk True Strike -> Twin Snakes feature

### DIFF
--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -223,6 +223,23 @@ internal class MonkTwinSnakes : CustomCombo
     }
 }
 
+internal class MonkTrueStrike : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkTrueStrikeFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == MNK.TrueStrike && level >= MNK.Levels.TwinSnakes)
+        {
+            var buff = FindEffect(MNK.Buffs.DisciplinedFist);
+            if (buff == null || buff.RemainingTime <= 6.0)
+                return MNK.TwinSnakes;
+        }
+
+        return actionID;
+    }
+}
+
 internal class MonkDemolish : CustomCombo
 {
     protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkAny;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -484,12 +484,17 @@ public enum CustomComboPreset
     [CustomComboInfo("Dragon Kick / Bootshine Feature", "Replace Dragon Kick with Bootshine if Leaden Fist is up.", MNK.JobID)]
     MonkBootshineFeature = 2011,
 
+    [ConflictingCombos(MonkTrueStrikeFeature)]
     [CustomComboInfo("Twin Snakes / True Strike Feature", "Replace Twin Snakes with True Strike if Twin Snakes has more than 6s remaining.", MNK.JobID)]
     MonkTwinSnakesFeature = 2013,
 
     [ParentCombo(MonkTwinSnakesFeature)]
     [CustomComboInfo("Formless Snakes Option", "While Formless Fist is active, do not replace Twin Snakes.", MNK.JobID)]
     MonkFormlessSnakesOption = 2015,
+
+    [ConflictingCombos(MonkTwinSnakesFeature)]
+    [CustomComboInfo("True Strike / Twin Snakes Feature", "Replace True Strike with Twin Snakes if Twin Snakes has less than 6s remaining.", MNK.JobID)]
+    MonkTrueStrikeFeature = 2016,
 
     [CustomComboInfo("Demolish / Snap Punch Feature", "Replace Demolish with Snap Punch if Demolish has more than 6s remaining on your current target.", MNK.JobID)]
     MonkDemolishFeature = 2014,


### PR DESCRIPTION
Similar to the existing Twin Snakes / True Strike feature, but instead replaces True Strike instead. Toggling this feature on but leaving the other feature off allows you to put both skills on the bar, with True Strike conditionally changes to Twin Snakes, but Twin Snakes stays as Twin Snakes unconditionally. This allows you to force a buff refresh before entering a burst window.