### PR TITLE
SMN: Summon Demi into Carbuncle when absent

### DIFF
--- a/XIVComboExpanded/Combos/SMN.cs
+++ b/XIVComboExpanded/Combos/SMN.cs
@@ -225,6 +225,9 @@ internal class SummonerDemiFeature : CustomCombo
     {
         if (actionID == SMN.Aethercharge || actionID == SMN.DreadwyrmTrance || actionID == SMN.SummonBahamut)
         {
+            if (IsEnabled(CustomComboPreset.SummonerDemiCarbuncleFeature) && !HasPetPresent())
+                return SMN.SummonCarbuncle;
+
             var gauge = GetJobGauge<SMNGauge>();
 
             if (IsEnabled(CustomComboPreset.SummonerDemiSearingLightFeature))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -986,6 +986,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Radiant Carbuncle Feature", "Change Radiant Aegis into Summon Carbuncle when no pet has been summoned.", SMN.JobID)]
     SummonerRadiantCarbuncleFeature = 2711,
 
+    [CustomComboInfo("Demi Carbuncle Feature", "Change Summon Bahamut into Summon Carbuncle when no pet has been summoned.", SMN.JobID)]
+    SummonerDemiCarbuncleFeature = 2716,
+
     #endregion
     // ====================================================================================
     #region WARRIOR


### PR DESCRIPTION
Change Summon Demi into Summon Carbuncle when pet is absent. This is similar to RadiantCarbundleFeature, but since Summon Demi is used in the opener and rotation, it's easier to notice when pet is missing and more intuitive to react with than Radiant Aegis, which is used on demand. Summon Demi (and variants) cannot be used without Carbuncle already summoned.