### PR TITLE
BLM: Option to delay Thunder->Sharpcast to avoid accidental usage

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -343,19 +343,27 @@ internal class BlackThunder : CustomCombo
     {
         if (actionID == BLM.Thunder3 || actionID == BLM.Thunder4)
         {
-
-            if (level >= BLM.Levels.EnhancedSharpcast2)
+            if (IsEnabled(CustomComboPreset.BlackThunderOption) && !IsThunderCastRecently(lastComboMove))
             {
-                if (HasCharges(BLM.Sharpcast) && !HasEffect(BLM.Buffs.Sharpcast))
-                    return BLM.Sharpcast;
-            }
-            else if (level >= BLM.Levels.Sharpcast)
-            {
-                if (IsOffCooldown(BLM.Sharpcast))
-                    return BLM.Sharpcast;
+                if (level >= BLM.Levels.EnhancedSharpcast2)
+                {
+                    if (HasCharges(BLM.Sharpcast) && !HasEffect(BLM.Buffs.Sharpcast))
+                        return BLM.Sharpcast;
+                }
+                else if (level >= BLM.Levels.Sharpcast)
+                {
+                    if (IsOffCooldown(BLM.Sharpcast))
+                        return BLM.Sharpcast;
+                }
             }
         }
 
         return actionID;
+    }
+
+    private bool IsThunderCastRecently(uint lastComboMove)
+    {
+        bool isGcdOnCooldown = IsOnCooldown(BLM.Thunder3); // shared with Thunder4
+        return isGcdOnCooldown && (lastComboMove == BLM.Thunder3 || lastComboMove == BLM.Thunder4);
     }
 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -176,6 +176,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Thunder 3/4 to Sharpcast", "Thunder 3 and Thunder 4 become Sharpcast when available.", BLM.JobID)]
     BlackThunderFeature = 2519,
 
+    [ParentCombo(BlackThunderFeature)]
+    [CustomComboInfo("Delay replacement after casting Thunder", "Delay changing Thunder into Sharpcast immediately after casting Thunder.", BLM.JobID)]
+    BlackThunderOption = 2520,
+
     #endregion
     // ====================================================================================
     #region BARD


### PR DESCRIPTION
When Thunder is procced and Sharpcast is active but still has another charge remaining, it's easy to double tap the key bound to Thunder with the intention of queuing the spell but instead casting Thunder and accidentally also use up the second Sharpcast charge as well. This is usually undesirable because it often leads to the Sharpcast buff expiring before it is actually needed.

This change adds an option to defer changing Thunder into Sharpcast until the GCD window for Thunder has elapsed.