### PR TITLE
BLM: Option to change Blizzard into Paradox only during Umbral Ice

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -211,8 +211,11 @@ internal class BlackBlizzard : CustomCombo
 
             if (IsEnabled(CustomComboPreset.BlackBlizzardFeature))
             {
-                if (level >= BLM.Levels.Paradox && gauge.IsParadoxActive && (gauge.InUmbralIce || LocalPlayer?.CurrentMp >= 1600))
-                    return BLM.Paradox;
+                if (level >= BLM.Levels.Paradox && gauge.IsParadoxActive)
+                {
+                    if (gauge.InUmbralIce || (!IsEnabled(CustomComboPreset.BlackBlizzardParadoxOption) && LocalPlayer?.CurrentMp >= 1600))
+                        return BLM.Paradox;
+                }
 
                 if (level >= BLM.Levels.Blizzard3)
                     return BLM.Blizzard3;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -155,6 +155,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Blizzard 1/3 Feature", "Replace Blizzard 1 with Blizzard 3 when unlocked and becomes Paradox when available.", BLM.JobID)]
     BlackBlizzardFeature = 2505,
 
+    [ParentCombo(BlackBlizzardFeature)]
+    [CustomComboInfo("Paradox only during Umbral Ice", "Only replace Blizzard with Paradox during Umbral Ice.", BLM.JobID)]
+    BlackBlizzardParadoxOption = 2521,
+
     [CustomComboInfo("Freeze/Flare Feature", "Freeze and Flare become whichever action you can currently use.", BLM.JobID)]
     BlackFreezeFlareFeature = 2506,
 


### PR DESCRIPTION
Since Paradox can still be cast using Fire spells, this gives more flexibility to rotation by allowing the player to renew Enochian at a reduced cast time using Blizzard compared to casting the Fire-aspected Paradox.