### PR TITLE
BLM: Umbral Soul into Transpose

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -82,7 +82,7 @@ internal class BlackFireBlizzard4 : CustomCombo
         {
             var gauge = GetJobGauge<BLMGauge>();
 
-            if (IsEnabled(CustomComboPreset.BlackUmbralSoulFeature))
+            if (IsEnabled(CustomComboPreset.BlackSpellsUmbralSoulFeature))
             {
                 if (level >= BLM.Levels.UmbralSoul && gauge.InUmbralIce && !HasTarget())
                     return BLM.UmbralSoul;
@@ -125,7 +125,7 @@ internal class BlackFireBlizzard4 : CustomCombo
 
 internal class BlackTranspose : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackManaFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackTransposeUmbralSoulFeature;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
@@ -135,6 +135,24 @@ internal class BlackTranspose : CustomCombo
 
             if (level >= BLM.Levels.UmbralSoul && gauge.IsEnochianActive && gauge.InUmbralIce)
                 return BLM.UmbralSoul;
+        }
+
+        return actionID;
+    }
+}
+
+internal class BlackUmbralSoul : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackUmbralSoulTransposeFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == BLM.UmbralSoul)
+        {
+            var gauge = GetJobGauge<BLMGauge>();
+
+            if (level < BLM.Levels.UmbralSoul || (gauge.IsEnochianActive && gauge.InAstralFire))
+                return BLM.Transpose;
         }
 
         return actionID;
@@ -203,7 +221,7 @@ internal class BlackBlizzard : CustomCombo
         {
             var gauge = GetJobGauge<BLMGauge>();
 
-            if (IsEnabled(CustomComboPreset.BlackUmbralSoulFeature))
+            if (IsEnabled(CustomComboPreset.BlackSpellsUmbralSoulFeature))
             {
                 if (level >= BLM.Levels.UmbralSoul && gauge.InUmbralIce && !HasTarget())
                     return BLM.UmbralSoul;
@@ -235,7 +253,7 @@ internal class BlackFreezeFlare : CustomCombo
         {
             var gauge = GetJobGauge<BLMGauge>();
 
-            if (IsEnabled(CustomComboPreset.BlackUmbralSoulFeature))
+            if (IsEnabled(CustomComboPreset.BlackSpellsUmbralSoulFeature))
             {
                 if (level >= BLM.Levels.UmbralSoul && gauge.InUmbralIce && !HasTarget())
                     return BLM.UmbralSoul;
@@ -294,7 +312,7 @@ internal class BlackBlizzard2 : CustomCombo
         {
             var gauge = GetJobGauge<BLMGauge>();
 
-            if (IsEnabled(CustomComboPreset.BlackUmbralSoulFeature))
+            if (IsEnabled(CustomComboPreset.BlackSpellsUmbralSoulFeature))
             {
                 if (level >= BLM.Levels.UmbralSoul && gauge.InUmbralIce && !HasTarget())
                     return BLM.UmbralSoul;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -135,8 +135,11 @@ public enum CustomComboPreset
     [CustomComboInfo("Enochian No Sync Feature", "Fire 4 and Blizzard 4 will not sync to Fire 1 and Blizzard 1.", BLM.JobID)]
     BlackEnochianNoSyncFeature = 2518,
 
-    [CustomComboInfo("Umbral Soul/Transpose Switcher", "Replace Transpose with Umbral Soul when Umbral Soul is usable.", BLM.JobID)]
-    BlackManaFeature = 2502,
+    [CustomComboInfo("Transpose into Umbral Soul", "Replace Transpose with Umbral Soul when Umbral Soul is usable.", BLM.JobID)]
+    BlackTransposeUmbralSoulFeature = 2502,
+
+    [CustomComboInfo("Umbral Soul into Transpose", "Replace Umbral Soul with Transpose when Umbral Soul is not usable.", BLM.JobID)]
+    BlackUmbralSoulTransposeFeature = 2522,
 
     [CustomComboInfo("(Between the) Ley Lines", "Replace Ley Lines with BTL when Ley Lines is active.", BLM.JobID)]
     BlackLeyLinesFeature = 2503,
@@ -168,7 +171,7 @@ public enum CustomComboPreset
     BlackFireBlizzard2Option = 2514,
 
     [CustomComboInfo("Umbral Soul Feature", "Replace your ice spells with Umbral Soul, while in Umbral Ice and having no target.", BLM.JobID)]
-    BlackUmbralSoulFeature = 2517,
+    BlackSpellsUmbralSoulFeature = 2517,
 
     [CustomComboInfo("Scathe/Xenoglossy Feature", "Scathe becomes Xenoglossy when available.", BLM.JobID)]
     BlackScatheFeature = 2507,


### PR DESCRIPTION
Similar to Transpose->Umbral Soul, but in reverse. This allows the unmodded Transpose to be used to to enter Astral Fire for [rotation optimization](https://www.thebalanceffxiv.com/jobs/casters/black-mage/advanced-guide/).