### PR TITLE
BLM: Fix Fire2 rotation and support Triplecast rotation

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -38,8 +38,10 @@ internal static class BLM
         public const ushort
             Thundercloud = 164,
             Firestarter = 165,
+            Swiftcast = 167,
             LeyLines = 737,
             Sharpcast = 867,
+            Triplecast = 1211,
             EnhancedFlare = 2960;
     }
 
@@ -69,6 +71,13 @@ internal static class BLM
             HighBlizzard2 = 82,
             EnhancedSharpcast2 = 88,
             Paradox = 90;
+    }
+
+    public static class MpCosts
+    {
+        public const ushort
+            Fire2 = 3000,
+            Flare = 800;
     }
 }
 
@@ -276,8 +285,28 @@ internal class BlackFire2 : CustomCombo
                     return actionID;
             }
 
-            if (level >= BLM.Levels.Flare && gauge.InAstralFire && (gauge.UmbralHearts == 1 || LocalPlayer?.CurrentMp < 3800 || HasEffect(BLM.Buffs.EnhancedFlare)))
-                return BLM.Flare;
+            if (level >= BLM.Levels.Flare && gauge.InAstralFire)
+            {
+                // Lv 50 rotation without Umbral Hearts
+                if (LocalPlayer?.CurrentMp < BLM.MpCosts.Fire2 + BLM.MpCosts.Flare)
+                    return BLM.Flare;
+
+                // Standard AoE rotation Fire2 until 1 Umbral Heart, followed by 2 Flare
+                if (gauge.UmbralHearts == 1 || (gauge.UmbralHearts == 0 && HasEffect(BLM.Buffs.EnhancedFlare)))
+                    return BLM.Flare;
+
+                if (IsEnabled(CustomComboPreset.BlackFire2TriplecastOption))
+                {
+                    int triplecasts = FindEffect(BLM.Buffs.Triplecast)?.StackCount ?? 0;
+
+                    // (Umbral Ice) Fire2 -> Triplecast -> Fire2 -> Swiftcast -> Flare -> Flare -> Manafont -> Flare
+                    if (gauge.UmbralHearts > 0 && triplecasts == 2)
+                        return BLM.Flare;
+
+                    if (triplecasts == 1)
+                        return BLM.Flare;
+                }
+            }
         }
 
         return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -161,6 +161,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Fire 2 Feature", "(High) Fire 2 becomes Flare in Astral Fire when only 1 Umbral Heart is active, less than 3000 mp, or during Enhanced Flare.", BLM.JobID)]
     BlackFire2Feature = 2508,
 
+    [ParentCombo(BlackFire2Feature)]
+    [CustomComboInfo("Fire 2 Triplecast Option", "Shorten rotation when Triplecast is active to make both Flare casts instant.", BLM.JobID)]
+    BlackFire2TriplecastOption = 2523,
+
     [CustomComboInfo("Ice 2 Feature", "(High) Blizzard 2 becomes Freeze in Umbral Ice.", BLM.JobID)]
     BlackBlizzard2Feature = 2509,
 


### PR DESCRIPTION
The standard AoE rotation is: `(Umbral Ice) Fire2 -> Fire2 -> Fire2 -> Flare -> Flare`
But the BlackFire2 combo causes the rotation to be: `(Umbral Ice) Fire2 -> Fire2 -> Flare -> Flare`

This is because the Fire2 cast during Astral Fire (i.e. second Fire2) grants Enhanced Flare while dropping the number of Umbral Hearts to 2. The `UmbralHearts == 1` condition never matches because of Enhanced Flare is active.

This change also adds a new option to modify the rotation when Triplecast is used so that the Flares are made instant cast.