### PR TITLE
BLM: Fix Thunder/Sharpcast delay option toggle

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -364,18 +364,18 @@ internal class BlackThunder : CustomCombo
     {
         if (actionID == BLM.Thunder3 || actionID == BLM.Thunder4)
         {
-            if (IsEnabled(CustomComboPreset.BlackThunderOption) && !IsThunderCastRecently(lastComboMove))
+            if (IsEnabled(CustomComboPreset.BlackThunderDelayOption) && IsThunderCastRecently(lastComboMove))
+                return actionID;
+
+            if (level >= BLM.Levels.EnhancedSharpcast2)
             {
-                if (level >= BLM.Levels.EnhancedSharpcast2)
-                {
-                    if (HasCharges(BLM.Sharpcast) && !HasEffect(BLM.Buffs.Sharpcast))
-                        return BLM.Sharpcast;
-                }
-                else if (level >= BLM.Levels.Sharpcast)
-                {
-                    if (IsOffCooldown(BLM.Sharpcast))
-                        return BLM.Sharpcast;
-                }
+                if (HasCharges(BLM.Sharpcast) && !HasEffect(BLM.Buffs.Sharpcast))
+                    return BLM.Sharpcast;
+            }
+            else if (level >= BLM.Levels.Sharpcast)
+            {
+                if (IsOffCooldown(BLM.Sharpcast))
+                    return BLM.Sharpcast;
             }
         }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -185,7 +185,7 @@ public enum CustomComboPreset
 
     [ParentCombo(BlackThunderFeature)]
     [CustomComboInfo("Delay replacement after casting Thunder", "Delay changing Thunder into Sharpcast immediately after casting Thunder.", BLM.JobID)]
-    BlackThunderOption = 2520,
+    BlackThunderDelayOption = 2520,
 
     #endregion
     // ====================================================================================


### PR DESCRIPTION
Fixes bug in option toggle for Thunder/Sharpcast delay causing the original feature to be disabled when the new option has not been enabled.