### PR TITLE
PLD: Split RoyalAuthority combo FoF behavior to a separate option

### DIFF
--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -77,7 +77,7 @@ internal class PaladinRoyalAuthority : CustomCombo
         if (actionID == PLD.RageOfHalone || actionID == PLD.RoyalAuthority)
         {
             // During FoF, prioritize the higher-potency Divine Might cast over Atonement and the normal combo chain
-            if (IsEnabled(CustomComboPreset.PaladinRoyalAuthorityDivineMightFeature))
+            if (IsEnabled(CustomComboPreset.PaladinRoyalAuthorityFightOrFlightFeature))
             {
                 if (HasEffect(PLD.Buffs.FightOrFlight) && HasEffect(PLD.Buffs.DivineMight))
                     return PLD.HolySpirit;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -611,9 +611,15 @@ public enum CustomComboPreset
     [CustomComboInfo("Royal Authority Combo", "Replace Royal Authority with its combo chain.", PLD.JobID)]
     PaladinRoyalAuthorityCombo = 1902,
 
-    [CustomComboInfo("Royal Authority Divine Might Feature", "Replace Royal Authority with Holy Spirit when Divine Might is active.", PLD.JobID)]
+    [ParentCombo(PaladinRoyalAuthorityCombo)]
+    [CustomComboInfo("Royal Authority Divine Might Feature", "Replace Royal Authority with Holy Spirit when Divine Might would overcap.", PLD.JobID)]
     PaladinRoyalAuthorityDivineMightFeature = 1912,
 
+    [ParentCombo(PaladinRoyalAuthorityCombo)]
+    [CustomComboInfo("Royal Authority Fight or Flight Feature", "Replace Royal Authority with Holy Spirit during Fight or Flight when Divine Might is active.", PLD.JobID)]
+    PaladinRoyalAuthorityFightOrFlightFeature = 1915,
+
+    [ParentCombo(PaladinRoyalAuthorityCombo)]
     [CustomComboInfo("Royal Authority Atonement Feature", "Replace Royal Authority with Atonement when under the effect of Sword Oath.", PLD.JobID)]
     PaladinRoyalAuthorityAtonementFeature = 1903,
 


### PR DESCRIPTION
The existing combo forces Divine Might proc to be used up during Fight or Flight window to maximize dps. But often the proc is useful to be saved for movement. It is currently not possible to save the proc for later.

This change splits out Holy Spirit usage during FoF to a separate option. This is a new option that will initially be disabled so the behavior of the original combo will be affected. Holy Spirit can still be casted manually during FoF using a dedicated key. I think it's a more deliberate playstyle that should be encouraged as the default. Anyone who has been using the original feature and is obsessed with maximizing dps would probably notice the change and discover the new option pretty quickly.