### PR TITLE
Fix Paladin Prominence combo stuck on Holy Circle when downleveled

### DIFF
--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -111,8 +111,9 @@ internal class PaladinRoyalAuthority : PaladinCombo
             // During FoF, prioritize the higher-potency Divine Might cast over Atonement and the normal combo chain
             if (IsEnabled(CustomComboPreset.PaladinRoyalAuthorityFightOrFlightFeature))
             {
-                if (HasEffect(PLD.Buffs.FightOrFlight) && HasEffect(PLD.Buffs.DivineMight) && HasMp(PLD.HolySpirit))
-                    return PLD.HolySpirit;
+                if (HasEffect(PLD.Buffs.FightOrFlight) && HasEffect(PLD.Buffs.DivineMight))
+                    if (level >= PLD.Levels.HolySpirit && HasMp(PLD.HolySpirit))
+                        return PLD.HolySpirit;
             }
 
             if (IsEnabled(CustomComboPreset.PaladinRoyalAuthorityAtonementFeature))
@@ -129,8 +130,9 @@ internal class PaladinRoyalAuthority : PaladinCombo
                     {
                         if (IsEnabled(CustomComboPreset.PaladinRoyalAuthorityDivineMightFeature))
                         {
-                            if (level >= PLD.Levels.HolySpirit && HasEffect(PLD.Buffs.DivineMight) && HasMp(PLD.HolySpirit))
-                                return PLD.HolySpirit;
+                            if (HasEffect(PLD.Buffs.DivineMight))
+                                if (level >= PLD.Levels.HolySpirit && HasMp(PLD.HolySpirit))
+                                    return PLD.HolySpirit;
                         }
 
                         // Royal Authority
@@ -157,11 +159,12 @@ internal class PaladinProminence : PaladinCombo
     {
         if (actionID == PLD.Prominence)
         {
-            // During FoF, prioritize the higher-potency Divine Might cast over Atonement and the normal combo chain
+            // During FoF, prioritize the higher-potency Divine Might cast over the normal combo chain
             if (IsEnabled(CustomComboPreset.PaladinProminenceDivineMightFeature))
             {
-                if (HasEffect(PLD.Buffs.FightOrFlight) && HasEffect(PLD.Buffs.DivineMight) && HasMp(PLD.HolyCircle))
-                    return PLD.HolyCircle;
+                if (HasEffect(PLD.Buffs.FightOrFlight) && HasEffect(PLD.Buffs.DivineMight))
+                    if (level >= PLD.Levels.HolyCircle && HasMp(PLD.HolyCircle))
+                        return PLD.HolyCircle;
             }
 
             if (comboTime > 0)
@@ -170,8 +173,9 @@ internal class PaladinProminence : PaladinCombo
                 {
                     if (IsEnabled(CustomComboPreset.PaladinProminenceDivineMightFeature))
                     {
-                        if (level >= PLD.Levels.HolyCircle && HasEffect(PLD.Buffs.DivineMight) && HasMp(PLD.HolyCircle))
-                            return PLD.HolyCircle;
+                        if (HasEffect(PLD.Buffs.DivineMight))
+                            if (level >= PLD.Levels.HolyCircle && HasMp(PLD.HolyCircle))
+                                return PLD.HolyCircle;
                     }
 
                     return PLD.Prominence;


### PR DESCRIPTION
Divine Might is available at level 64 but but Holy Circle is level 72. In a level 70 dungeon, the AoE combo can get stuck on Holy Circle if the Divine Might buff is first acquired using the single-target combo, followed by activating Fight or Flight, then using the AoE combo.

The single-target combo doesn't have this issue because Holy Spirit is a level 64 spell, so it is always available when the Divine Might buff is active. I added level requirement to the Holy Spirit condition just to make it consistent with Holy Circle.