### PR TITLE
DOL Hook replacement features

### DIFF
--- a/XIVComboExpanded/Combos/DOL.cs
+++ b/XIVComboExpanded/Combos/DOL.cs
@@ -12,6 +12,7 @@ internal static class DOL
         SolidReason = 232,
         Cast = 289,
         Hook = 296,
+        Mooch = 297,
         CastLight = 2135,
         Snagging = 4100,
         SurfaceSlap = 4595,
@@ -99,6 +100,28 @@ internal class FisherCast : CustomCombo
             {
                 if (HasCondition(ConditionFlag.Diving))
                     return DOL.Gig;
+            }
+        }
+
+        if (actionID == DOL.Hook)
+        {
+
+            if (IsEnabled(CustomComboPreset.DolHookGigFeature))
+            {
+                if (HasCondition(ConditionFlag.Diving))
+                    return DOL.Gig;
+            }
+
+            if (IsEnabled(CustomComboPreset.DolHookMoochFeature))
+            {
+                if (CanUseAction(DOL.Mooch))
+                    return DOL.Mooch;
+            }
+
+            if (IsEnabled(CustomComboPreset.DolHookCastFeature))
+            {
+                if (!HasCondition(ConditionFlag.Fishing))
+                    return DOL.Cast;
             }
         }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2856,6 +2856,24 @@ public enum CustomComboPreset
     DolCastGigFeature = 51003,
 
     [SectionCombo("Disciple of the Ocean")]
+    [IconsCombo([DOL.Hook, UTL.ArrowLeft, DOL.Cast])]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Hook / Cast Feature", "Replaces Hook with Cast when not fishing.", DOL.JobID)]
+    DolHookCastFeature = 51009,
+
+    [SectionCombo("Disciple of the Ocean")]
+    [IconsCombo([DOL.Hook, UTL.ArrowLeft, DOL.Mooch])]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Hook / Mooch Feature", "Replaces Hook with Mooch when available.", DOL.JobID)]
+    DolHookMoochFeature = 51010,
+
+    [SectionCombo("Disciple of the Ocean")]
+    [IconsCombo([DOL.Hook, UTL.ArrowLeft, DOL.Gig])]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Hook / Gig Feature", "Replaces Hook with Gig when underwater.", DOL.JobID)]
+    DolHookGigFeature = 51011,
+
+    [SectionCombo("Disciple of the Ocean")]
     [IconsCombo([DOL.SurfaceSlap, UTL.ArrowLeft, DOL.VeteranTrade])]
     [ExpandedCustomCombo]
     [CustomComboInfo("Surface Slap / Veteran Trade Feature", "Replace Surface Slap with Veteran Trade when underwater.", DOL.JobID)]


### PR DESCRIPTION
Adds Hook -> Cast, Hook -> Gig, and Hook -> Mooch for fishers.

This is mostly to facilitate having mooch on the same button as cast while still allowing you to have a separate cast button to skip mooching.