### PR TITLE
Add Sage Phlegma burst option

### DIFF
--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -150,10 +150,10 @@ internal class SageDosis : CustomCombo
                 var spendToAvoidOvercap = level >= SGE.Levels.Psyche &&
                     psycheCooldown.IsCooldown &&
                     psycheCooldown.CooldownRemaining <= 30 &&
-                    GetRemainingCharges(phlegma) >= 2 &&
-                    CanUseAction(OriginalHook(SGE.Phlegma));
+                    GetRemainingCharges(phlegma) >= 2;
 
                 if (phlegma != 0 && IsCooldownUsable(phlegma) &&
+                    CanUseAction(OriginalHook(SGE.Phlegma)) &&
                     (raidBuffActive || firstBurstFallback || spendToAvoidOvercap))
                     return OriginalHook(SGE.Phlegma);
             }

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -145,16 +145,17 @@ internal class SageDosis : CustomCombo
                 var combatElapsed = Service.ComboCache.CombatElapsed.TotalSeconds;
                 var firstBurstFallback = !Service.ComboCache.RaidBuffDetectedThisCombat &&
                     combatElapsed >= 10 && combatElapsed <= 20;
+                var burstPhaseActive = raidBuffActive || firstBurstFallback;
+                Service.ComboCache.UpdateRaidBurst(burstPhaseActive);
 
-                var psycheCooldown = GetCooldown(SGE.Psyche);
-                var spendToAvoidOvercap = level >= SGE.Levels.Psyche &&
-                    psycheCooldown.IsCooldown &&
-                    psycheCooldown.CooldownRemaining <= 30 &&
-                    GetRemainingCharges(phlegma) >= 2;
+                var nextBurstIn = Service.ComboCache.NextRaidBurstIn;
+                var spendToAvoidOvercap = !burstPhaseActive &&
+                    GetRemainingCharges(phlegma) >= 2 &&
+                    (!nextBurstIn.HasValue || nextBurstIn.Value.TotalSeconds > 20);
+                var inPhlegmaRange = CurrentTarget!.CurrentDistance <= 6;
 
                 if (phlegma != 0 && IsCooldownUsable(phlegma) &&
-                    CanUseAction(OriginalHook(SGE.Phlegma)) &&
-                    (raidBuffActive || firstBurstFallback || spendToAvoidOvercap))
+                    inPhlegmaRange && (burstPhaseActive || spendToAvoidOvercap))
                     return OriginalHook(SGE.Phlegma);
             }
 

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -78,7 +78,7 @@ internal static class SGE
 
         public static readonly ushort[] Target =
         [
-            638,  // Mug
+            3183, // Mug
             3849, // Dokumori
             1221, // Chain Stratagem
         ];

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -59,6 +59,31 @@ internal static class SGE
             EukrasianDosis3 = 2616;
     }
 
+    public static class RaidBuffs
+    {
+        public static readonly ushort[] Player =
+        [
+            1878, // Divination
+            141,  // Battle Voice
+            2722, // Radiant Finale
+            1822, // Technical Finish
+            786,  // Battle Litany
+            1185, // Brotherhood
+            3685, // Starry Muse
+            1239, // Embolden (self)
+            1297, // Embolden (party members)
+            2599, // Arcane Circle
+            2703, // Searing Light
+        ];
+
+        public static readonly ushort[] Target =
+        [
+            638,  // Mug
+            3849, // Dokumori
+            1221, // Chain Stratagem
+        ];
+    }
+
     public static class Levels
     {
         public const ushort
@@ -103,6 +128,34 @@ internal class SageDosis : CustomCombo
             {
                 if (level >= SGE.Levels.Psyche && IsCooldownUsable(SGE.Psyche) && TargetIsEnemy() && InCombat())
                     return OriginalHook(SGE.Psyche);
+            }
+
+            if (IsEnabled(CustomComboPreset.SageDosisPhlegmaBurst) && TargetIsEnemy() && InCombat())
+            {
+                var phlegma =
+                    level >= SGE.Levels.Phlegma3 ? SGE.Phlegma3 :
+                    level >= SGE.Levels.Phlegma2 ? SGE.Phlegma2 :
+                    level >= SGE.Levels.Phlegma ? SGE.Phlegma : 0;
+
+                var raidBuffActive = Array.Exists(SGE.RaidBuffs.Player, HasEffectAny) ||
+                    Array.Exists(SGE.RaidBuffs.Target, TargetHasEffectAny);
+                if (raidBuffActive)
+                    Service.ComboCache.RaidBuffDetectedThisCombat = true;
+
+                var combatElapsed = Service.ComboCache.CombatElapsed.TotalSeconds;
+                var firstBurstFallback = !Service.ComboCache.RaidBuffDetectedThisCombat &&
+                    combatElapsed >= 10 && combatElapsed <= 20;
+
+                var psycheCooldown = GetCooldown(SGE.Psyche);
+                var spendToAvoidOvercap = level >= SGE.Levels.Psyche &&
+                    psycheCooldown.IsCooldown &&
+                    psycheCooldown.CooldownRemaining <= 30 &&
+                    GetRemainingCharges(phlegma) >= 2 &&
+                    CanUseAction(OriginalHook(SGE.Phlegma));
+
+                if (phlegma != 0 && IsCooldownUsable(phlegma) &&
+                    (raidBuffActive || firstBurstFallback || spendToAvoidOvercap))
+                    return OriginalHook(SGE.Phlegma);
             }
 
             if (IsEnabled(CustomComboPreset.SageDoTFeature) && TargetIsEnemy() && InCombat())

--- a/XIVComboExpanded/CustomComboCache.cs
+++ b/XIVComboExpanded/CustomComboCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Dalamud.Game;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
@@ -24,6 +25,19 @@ internal partial class CustomComboCache : IDisposable
     private readonly Dictionary<uint, byte> cooldownGroupCache = new();
     private readonly Dictionary<Type, JobGaugeBase> jobGaugeCache = new();
     private readonly Dictionary<(uint ActionID, uint ClassJobID, byte Level), (ushort CurrentMax, ushort Max)> chargesCache = new();
+    private DateTime? combatStartedAt;
+    private bool wasInCombat;
+
+    /// <summary>
+    /// Gets the time elapsed since the player entered combat.
+    /// </summary>
+    internal TimeSpan CombatElapsed
+        => this.combatStartedAt.HasValue ? DateTime.UtcNow - this.combatStartedAt.Value : TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a recognized raid buff was seen during the current combat.
+    /// </summary>
+    internal bool RaidBuffDetectedThisCombat { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomComboCache"/> class.
@@ -142,6 +156,19 @@ internal partial class CustomComboCache : IDisposable
 
     private unsafe void Framework_Update(IFramework framework)
     {
+        var inCombat = Service.Condition[ConditionFlag.InCombat];
+        if (inCombat && !this.wasInCombat)
+        {
+            this.combatStartedAt = DateTime.UtcNow;
+            this.RaidBuffDetectedThisCombat = false;
+        }
+        else if (!inCombat)
+        {
+            this.combatStartedAt = null;
+            this.RaidBuffDetectedThisCombat = false;
+        }
+
+        this.wasInCombat = inCombat;
         this.statusCache.Clear();
         this.cooldownCache.Clear();
     }

--- a/XIVComboExpanded/CustomComboCache.cs
+++ b/XIVComboExpanded/CustomComboCache.cs
@@ -26,6 +26,8 @@ internal partial class CustomComboCache : IDisposable
     private readonly Dictionary<Type, JobGaugeBase> jobGaugeCache = new();
     private readonly Dictionary<(uint ActionID, uint ClassJobID, byte Level), (ushort CurrentMax, ushort Max)> chargesCache = new();
     private DateTime? combatStartedAt;
+    private DateTime? raidBurstStartedAt;
+    private bool raidBurstWasActive;
     private bool wasInCombat;
 
     /// <summary>
@@ -38,6 +40,34 @@ internal partial class CustomComboCache : IDisposable
     /// Gets or sets a value indicating whether a recognized raid buff was seen during the current combat.
     /// </summary>
     internal bool RaidBuffDetectedThisCombat { get; set; }
+
+    /// <summary>
+    /// Gets the time remaining until the next tracked two-minute raid burst.
+    /// </summary>
+    internal TimeSpan? NextRaidBurstIn
+    {
+        get
+        {
+            if (!this.raidBurstStartedAt.HasValue)
+                return null;
+
+            var elapsed = (DateTime.UtcNow - this.raidBurstStartedAt.Value).TotalSeconds;
+            var remaining = Math.Max(0, 120 - elapsed);
+            return TimeSpan.FromSeconds(remaining);
+        }
+    }
+
+    /// <summary>
+    /// Updates the tracked raid-burst state and anchors a new cycle on its rising edge.
+    /// </summary>
+    /// <param name="active">Whether a recognized burst phase is currently active.</param>
+    internal void UpdateRaidBurst(bool active)
+    {
+        if (active && !this.raidBurstWasActive)
+            this.raidBurstStartedAt = DateTime.UtcNow;
+
+        this.raidBurstWasActive = active;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomComboCache"/> class.
@@ -160,11 +190,15 @@ internal partial class CustomComboCache : IDisposable
         if (inCombat && !this.wasInCombat)
         {
             this.combatStartedAt = DateTime.UtcNow;
+            this.raidBurstStartedAt = null;
+            this.raidBurstWasActive = false;
             this.RaidBuffDetectedThisCombat = false;
         }
         else if (!inCombat)
         {
             this.combatStartedAt = null;
+            this.raidBurstStartedAt = null;
+            this.raidBurstWasActive = false;
             this.RaidBuffDetectedThisCombat = false;
         }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2059,7 +2059,7 @@ public enum CustomComboPreset
     [IconsCombo([SGE.Dosis, UTL.ArrowLeft, SGE.Phlegma, UTL.Blank, SGE.Phlegma, UTL.Checkmark])]
     [SectionCombo("Damage")]
     [ExpandedCustomCombo]
-    [CustomComboInfo("Dosis into Phlegma during raid buffs", "Replace Dosis with Phlegma when a recognized raid damage buff is active on you or a recognized raid damage debuff is active on your target. If none are detected, treat 10-20 seconds after entering combat as the first burst window. Also spend one Phlegma at two charges when the next Psyche burst is 30 seconds or less away and the target is in range.", SGE.JobID)]
+    [CustomComboInfo("Dosis into Phlegma during raid buffs", "Replace Dosis with Phlegma when the target is in Phlegma range and a recognized raid damage buff is active on you or a recognized raid damage debuff is active on your target. If none are detected, treat 10-20 seconds after entering combat as the first burst window. Also spend one Phlegma at two charges when the next Psyche burst is 30 seconds or less away.", SGE.JobID)]
     SageDosisPhlegmaBurst = 4021,
 
     [IconsCombo([SGE.Dyskrasia, UTL.ArrowLeft, SGE.Psyche, UTL.Blank, SGE.Psyche, UTL.Clock])]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2059,7 +2059,7 @@ public enum CustomComboPreset
     [IconsCombo([SGE.Dosis, UTL.ArrowLeft, SGE.Phlegma, UTL.Blank, SGE.Phlegma, UTL.Checkmark])]
     [SectionCombo("Damage")]
     [ExpandedCustomCombo]
-    [CustomComboInfo("Dosis into Phlegma during raid buffs", "Replace Dosis with Phlegma when the target is in Phlegma range and a recognized raid damage buff is active on you or a recognized raid damage debuff is active on your target. If none are detected, treat 10-20 seconds after entering combat as the first burst window. Also spend one Phlegma at two charges when the next Psyche burst is 30 seconds or less away.", SGE.JobID)]
+    [CustomComboInfo("Dosis into Phlegma during raid buffs", "Replace Dosis with Phlegma when the target is within 6 yalms and a recognized raid damage buff is active on you or a recognized raid damage debuff is active on your target. If none are detected, treat 10-20 seconds after entering combat as the first burst window. After detecting burst, track the next two-minute burst and spend at two Phlegma charges only while it is more than 20 seconds away.", SGE.JobID)]
     SageDosisPhlegmaBurst = 4021,
 
     [IconsCombo([SGE.Dyskrasia, UTL.ArrowLeft, SGE.Psyche, UTL.Blank, SGE.Psyche, UTL.Clock])]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2056,6 +2056,12 @@ public enum CustomComboPreset
     [CustomComboInfo("Dosis Psyche Feature", "Replace Dosis with Psyche when cooldown is available.", SGE.JobID)]
     SageDosisPsyche = 4014,
 
+    [IconsCombo([SGE.Dosis, UTL.ArrowLeft, SGE.Phlegma, UTL.Blank, SGE.Phlegma, UTL.Checkmark])]
+    [SectionCombo("Damage")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Dosis into Phlegma during raid buffs", "Replace Dosis with Phlegma when a recognized raid damage buff is active on you or a recognized raid damage debuff is active on your target. If none are detected, treat 10-20 seconds after entering combat as the first burst window. Also spend one Phlegma at two charges when the next Psyche burst is 30 seconds or less away and the target is in range.", SGE.JobID)]
+    SageDosisPhlegmaBurst = 4021,
+
     [IconsCombo([SGE.Dyskrasia, UTL.ArrowLeft, SGE.Psyche, UTL.Blank, SGE.Psyche, UTL.Clock])]
     [SectionCombo("Damage")]
     [ExpandedCustomCombo]


### PR DESCRIPTION
## Summary

- add a Sage option that replaces Dosis I/II/III with the level-appropriate Phlegma during recognized party burst buffs
- recognize raid damage buffs on the player and raid damage debuffs on the current target regardless of effect owner
- treat 10-20 seconds after combat begins as a fallback first-burst window when no recognized raid effect has been detected
- spend a Phlegma at two charges when Psyche indicates the next burst is at most 30 seconds away and Phlegma is usable on the target
